### PR TITLE
Fix reportes del mismo día e importación y exportación de la información de la base de datos

### DIFF
--- a/SistemaFacturación/Md_BackupDB.vb
+++ b/SistemaFacturación/Md_BackupDB.vb
@@ -17,9 +17,31 @@ Module Md_BackupDB
         End If
 
         Try
+            Dim conexionSetting As System.Configuration.ConnectionStringSettings = ConfigurationManager.ConnectionStrings("conexionString")
+            If conexionSetting Is Nothing Then
+                msgError("No se pudo encontrar la conexión")
+            End If
             ' Obtener la ruta de la base de datos actual
-            Dim strsplit As String() = ConfigurationManager.ConnectionStrings("conexionString").ConnectionString.Split("=")
-            DBActual = strsplit(1).Trim()
+            Dim strConexion As String = conexionSetting.ConnectionString
+
+            If strConexion.Contains("|DataDirectory|") Then
+                ' Obtener la ruta completa del ejecutable
+                Dim appPath As String = System.Reflection.Assembly.GetExecutingAssembly().Location
+                ' Obtener solo el directorio de esa ruta
+                Dim appDir As String = System.IO.Path.GetDirectoryName(appPath)
+                ' Reemplazar la cadena por la ruta del directorio
+                DBActual = strConexion.Replace("Data Source=|DataDirectory|", appDir)
+
+            Else
+                ' Si no tiene |DataDirectory|, asumimos que es una ruta completa.
+                Dim strsplit As String() = strConexion.Split("=")
+                If strsplit.Length <= 1 Then
+                    MsgBox("Error en el formato de la cadena de conexión.", MsgBoxStyle.Exclamation, "Error")
+                    Return
+                End If
+                DBActual = strsplit(1).Trim()
+
+            End If
 
             ' Se copia la base de datos a un nuevo archivo
             File.Copy(DBActual, respaldo, True)
@@ -35,9 +57,31 @@ Module Md_BackupDB
 #Region "importar"
     Friend Sub ImportarDB(respaldo As String)
         Try
+            Dim conexionSetting As System.Configuration.ConnectionStringSettings = ConfigurationManager.ConnectionStrings("conexionString")
+            If conexionSetting Is Nothing Then
+                msgError("No se pudo encontrar la conexión")
+            End If
             ' Obtener la ruta de la base de datos actual
-            Dim strsplit As String() = ConfigurationManager.ConnectionStrings("conexionString").ConnectionString.Split("=")
-            DBActual = strsplit(1).Trim()
+            Dim strConexion As String = conexionSetting.ConnectionString
+
+            If strConexion.Contains("|DataDirectory|") Then
+                ' Obtener la ruta completa del ejecutable
+                Dim appPath As String = System.Reflection.Assembly.GetExecutingAssembly().Location
+                ' Obtener solo el directorio de esa ruta
+                Dim appDir As String = System.IO.Path.GetDirectoryName(appPath)
+                ' Reemplazar la cadena por la ruta del directorio
+                DBActual = strConexion.Replace("Data Source=|DataDirectory|", appDir)
+
+            Else
+                ' Si no tiene |DataDirectory|, asumimos que es una ruta completa.
+                Dim strsplit As String() = strConexion.Split("=")
+                If strsplit.Length <= 1 Then
+                    MsgBox("Error en el formato de la cadena de conexión.", MsgBoxStyle.Exclamation, "Error")
+                    Return
+                End If
+                DBActual = strsplit(1).Trim()
+
+            End If
 
             ' Se copia el respaldo en la base de datos que se encuentra en la posición actual
             File.Copy(respaldo, DBActual, True)

--- a/SistemaFacturación/Md_Reportes.vb
+++ b/SistemaFacturación/Md_Reportes.vb
@@ -45,12 +45,21 @@ Module Md_Reportes
 
 
     Private Async Function ObtenerListaVentas(stringConexion As String, desde As Date, hasta As Date, t As DataSet) As Task(Of List(Of Cls_Venta))
-        ' ... El código interno de este método no necesita cambios ya que no realiza operaciones I/O asíncronas
-        ' El uso de un DataAdapter es síncrono por naturaleza, pero puedes envolverlo en un Task.Run
-        ' para que se ejecute en un hilo secundario y no bloquee el hilo principal de la UI.
         Return Await Task.Run(Function()
+                                  Dim fechaInicioFiltrada As Date
+                                  Dim fechaFinFiltrada As Date
+
+                                  ' Valida si las fechas 'desde' y 'hasta' son el mismo día.
+                                  If desde.Date = hasta.Date Then
+                                      ' Si es el mismo día, ajusta el rango para cubrir el día completo.
+                                      fechaInicioFiltrada = desde.Date
+                                      fechaFinFiltrada = hasta.Date.AddDays(1)
+                                  Else
+                                      ' Si es un rango de días, usa las fechas originales sin modificar las horas.
+                                      fechaInicioFiltrada = desde
+                                      fechaFinFiltrada = hasta
+                                  End If
                                   Using db As New SQLiteConnection(stringConexion)
-                                      ' ... Resto del código original
                                       Try
                                           db.Open()
                                           Dim consulta As String = "SELECT f.num_factura As '# Fact', " &
@@ -62,8 +71,8 @@ Module Md_Reportes
                                                                   "INNER JOIN clientes c ON c.ID = f.ID_Cliente " &
                                                                   "WHERE fecha_emision >= @fechaInicio AND fecha_emision < @fechaFin AND cobrada != 0;"
                                           Using cmd As New SQLiteCommand(consulta, db)
-                                              cmd.Parameters.AddWithValue("@fechaInicio", desde)
-                                              cmd.Parameters.AddWithValue("@fechaFin", hasta)
+                                              cmd.Parameters.AddWithValue("@fechaInicio", fechaInicioFiltrada)
+                                              cmd.Parameters.AddWithValue("@fechaFin", fechaFinFiltrada)
 
                                               Using da As New SQLiteDataAdapter(cmd)
                                                   If t.Tables.Count > 0 Then


### PR DESCRIPTION

- Ahora si la fecha es la misma entre las 2 fechas del rango de reportes de ventas los productos ya se deberíoa de cargar bien a contar desde las 00 de ese día hasta las 00 del siguiente
- Resolves #18 : Se arregló un error en el que debido al cambio de conexión por defecto con la base de datos ya no funcionaban correctamente las importaciones y exportaciones de las bases de datos