### PR TITLE
Se eliminó el label que mostraba la ruta de la conexión con la DB y modificación en agregar productos

### DIFF
--- a/SistemaFacturación/ConfigGeneral.vb
+++ b/SistemaFacturación/ConfigGeneral.vb
@@ -15,7 +15,7 @@ Public Class ConfigGeneral
 
     Private Sub cargarDBConfigInfo()
         ' Cargar información de la conexión actual
-        LBL_DireccionConexionActual.Text = GetDbPath()
+        'LBL_DireccionConexionActual.Text = GetDbPath()
         'Dim strConn As String = ObtenerConnectionString("DbConnectionString")
         'If Not String.IsNullOrEmpty(strConn) Then
         '    Dim strConnParts As String() = strConn.Split("="c)

--- a/SistemaFacturación/P_Caja.vb
+++ b/SistemaFacturación/P_Caja.vb
@@ -233,11 +233,12 @@ Public Class P_Caja
         Dim Subtotal As Double = cant * Convert.ToInt32(precioVenta)
         Dim row As String() = {ID, codigo, nombre, precioVenta, cant, Subtotal}
         DGV_Caja.Columns(0).Visible = False
-        DGV_Caja.Rows.Add(row)
+        Dim filaNueva As Integer = DGV_Caja.Rows.Add(row)
         TXT_BuscarProducto.Clear()
         ValidarListView()
-        TXT_BuscarProducto.Focus()
         CargarTotal()
+        DGV_Caja.CurrentCell = DGV_Caja.Rows(filaNueva).Cells(4)
+        DGV_Caja.BeginEdit(True)
     End Sub
 
     Friend Sub CargarTotal()
@@ -309,6 +310,7 @@ Public Class P_Caja
 
         ' Recalcula el total de la factura
         CargarTotal()
+        TXT_BuscarProducto.Focus()
     End Sub
 
     Private Sub P_Caja_Shown(sender As Object, e As EventArgs) Handles MyBase.Shown


### PR DESCRIPTION
- Se eliminó el label dque mostraba la conexión con la base de datos ya que es innecesario ahora
- Ahora al agregar productos por medio de los botones de favoritos se seleccionará automaticamente la casilla de la cantidad para que se pueda ingresar directamente este dato sin tener que presionar click sobre esta
- En un cambio futuro se agregará que al seleccioanr cualquier parte de la fila se selecciona automáticamene la casilla de cantidad para mejorar la fluidez del trabajo