### PR TITLE
Arreglo de crear y eliminar cuentas y actualización del ensamblado

### DIFF
--- a/SistemaFacturación/Md_PROCESOS_BD.vb
+++ b/SistemaFacturación/Md_PROCESOS_BD.vb
@@ -107,9 +107,8 @@ Module Md_PROCESOS_BD
     Friend Async Function ELIMINAR_FACT(ByVal ID As Integer) As Task(Of Boolean)
         Return Await Task.Run(Function()
                                   Dim resultado As Boolean = False
-                                  Dim stringConexion As String = ConfigurationManager.ConnectionStrings("conexionString").ConnectionString
 
-                                  Using db As New SQLiteConnection(stringConexion)
+                                  Using db As New SQLiteConnection(GetConnectionString())
                                       ' Se inicia un proceso de transacción
                                       db.Open()
                                       Dim transaction As SQLiteTransaction = db.BeginTransaction()

--- a/SistemaFacturación/My Project/AssemblyInfo.vb
+++ b/SistemaFacturación/My Project/AssemblyInfo.vb
@@ -28,5 +28,5 @@ Imports System.Runtime.InteropServices
 '      Revisión
 '
 
-<Assembly: AssemblyVersion("2.3.2")>
-<Assembly: AssemblyFileVersion("2.3.2")>
+<Assembly: AssemblyVersion("2.3.3")>
+<Assembly: AssemblyFileVersion("2.3.3")>

--- a/SistemaFacturación/P_Caja.vb
+++ b/SistemaFacturación/P_Caja.vb
@@ -340,7 +340,7 @@ Public Class P_Caja
     Private Async Function GuardarOActualizarCuenta(comentarioRecibido As String, actualizar_factura_cobrar As Boolean) As Task(Of String)
         Return Await Task.Run(Function()
                                   ' Iniciar una transacción de base de datos
-                                  Dim dbConnection As New SQLiteConnection(ConfigurationManager.ConnectionStrings("conexionString").ConnectionString)
+                                  Dim dbConnection As New SQLiteConnection(GetConnectionString())
                                   dbConnection.Open()
                                   Dim transaction As SQLiteTransaction = dbConnection.BeginTransaction()
 


### PR DESCRIPTION
- Se arregló un error en el que por los cambios en la conexión con la base de datos ya no se podía trabajar con las cuentas por cobrar