### PR TITLE
Agregar el mismo numero ya no lo duplica, Se cambio el manejo de la vista de datos de facturas y visualización y reimpresion de facturas desde el reporte de ventas

### DIFF
--- a/SistemaFacturación/Cls_DatosFactura.vb
+++ b/SistemaFacturación/Cls_DatosFactura.vb
@@ -1,0 +1,13 @@
+﻿Public Class Cls_DatosFactura
+    Public Property IdFactura As Integer
+    Public Property NumFactura As Integer
+    Public Property Fecha As String
+    Public Property Cliente As String
+    Public Property Cajero As String
+    Public Property Efectivo As String
+    Public Property Tarjeta As String
+    Public Property Vuelto As String
+    Public Property TipoPago As String
+    Public Property Comentario As String
+    Public Property TotalCaja As String
+End Class

--- a/SistemaFacturación/Cls_ReporteVentas.vb
+++ b/SistemaFacturación/Cls_ReporteVentas.vb
@@ -1,13 +1,13 @@
 ﻿Imports SistemaFacturaciónCommon.Cls_Venta
 Public Class Cls_ReporteVentas
-    Public ListaVentas As New List(Of Cls_Venta)
+    Public ListaVentas As New List(Of Cls_DatosFactura)
     Public total_ventas As Decimal
     Public num_ventas As Integer
     Public ventas_efectivo As Decimal
     Public ventas_tarjeta As Decimal
     Public ProductoMasVendido As Cls_ProductosMasVendidos
 
-    Public Sub New(listaVentas As List(Of Cls_Venta), total_ventas As Decimal, num_ventas As Integer, ventas_efectivo As Decimal, ventas_tarjeta As Decimal, productoMasVendido As Cls_ProductosMasVendidos)
+    Public Sub New(listaVentas As List(Of Cls_DatosFactura), total_ventas As Decimal, num_ventas As Integer, ventas_efectivo As Decimal, ventas_tarjeta As Decimal, productoMasVendido As Cls_ProductosMasVendidos)
         Me.ListaVentas = listaVentas
         Me.total_ventas = total_ventas
         Me.num_ventas = num_ventas

--- a/SistemaFacturación/Cls_Venta.vb
+++ b/SistemaFacturación/Cls_Venta.vb
@@ -1,4 +1,5 @@
 ﻿Public Class Cls_Venta
+    Public Property ID As Integer
     Public Property Num_factura As String
     Public Property Fecha As Date
     Public Property Cliente As String
@@ -7,7 +8,8 @@
     Public Property Total As Decimal
     Public Property Tipo_venta As String
 
-    Sub New(num_factura As String, fecha As Date, cliente As String, total As Decimal, tipo_venta As String, efectivo As Decimal, tarjeta As Decimal)
+    Sub New(id As Integer, num_factura As String, fecha As Date, cliente As String, total As Decimal, tipo_venta As String, efectivo As Decimal, tarjeta As Decimal)
+        Me.ID = id
         Me.Num_factura = num_factura
         Me.Fecha = fecha
         Me.Cliente = cliente

--- a/SistemaFacturación/Md_Reportes.vb
+++ b/SistemaFacturación/Md_Reportes.vb
@@ -4,21 +4,21 @@ Imports System.Data.SQLite
 Module Md_Reportes
     Friend Async Function GenerarReporte(desde As Date, hasta As Date, t As DataSet) As Task(Of Cls_ReporteVentas)
         Try
-            Dim listaVentas As List(Of Cls_Venta) = Await ObtenerListaVentas(desde, hasta, t)
+            Dim listaVentas As List(Of Cls_DatosFactura) = Await ObtenerListaVentas(desde, hasta, t)
 
             Dim totalVentas As Decimal = 0D
             Dim ventasEfectivo As Decimal = 0D
             Dim ventasTarjeta As Decimal = 0D
 
-            For Each venta As Cls_Venta In listaVentas
-                totalVentas += venta.Total
-                If venta.Tipo_venta = "Efectivo" Then
-                    ventasEfectivo += venta.Total
-                ElseIf venta.Tipo_venta = "Mixto" Then
+            For Each venta As Cls_DatosFactura In listaVentas
+                totalVentas += venta.TotalCaja
+                If venta.TipoPago = "Efectivo" Then
+                    ventasEfectivo += venta.TotalCaja
+                ElseIf venta.TipoPago = "Mixto" Then
                     ventasEfectivo += venta.Efectivo
                     ventasTarjeta += venta.Tarjeta
                 Else
-                    ventasTarjeta += venta.Total
+                    ventasTarjeta += venta.TotalCaja
                 End If
             Next
 
@@ -42,7 +42,7 @@ Module Md_Reportes
     End Function
 
 
-    Private Async Function ObtenerListaVentas(desde As Date, hasta As Date, t As DataSet) As Task(Of List(Of Cls_Venta))
+    Private Async Function ObtenerListaVentas(desde As Date, hasta As Date, t As DataSet) As Task(Of List(Of Cls_DatosFactura))
         Return Await Task.Run(Function()
                                   Dim fechaInicioFiltrada As Date
                                   Dim fechaFinFiltrada As Date
@@ -60,14 +60,30 @@ Module Md_Reportes
                                   Using db As New SQLiteConnection(GetConnectionString())
                                       Try
                                           db.Open()
-                                          Dim consulta As String = "SELECT f.num_factura As '# Fact', " &
-                                                                  "f.fecha_emision As 'Fecha de emisión', " &
-                                                                  "c.nombre As 'Nombre', f.efectivo_cliente as 'Efectivo', " &
-                                                                  "f.tarjeta_cliente as 'Tarjeta', f.total As 'Total', " &
-                                                                  "f.tipo_venta As 'tipo' " &
-                                                                  "FROM factura f " &
-                                                                  "INNER JOIN clientes c ON c.ID = f.ID_Cliente " &
-                                                                  "WHERE fecha_emision >= @fechaInicio AND fecha_emision < @fechaFin AND cobrada != 0;"
+                                          Dim consulta As String = "SELECT 
+                                                                        f.ID,
+                                                                        f.num_factura AS '# Fact',
+                                                                        f.fecha_emision AS 'Fecha de emisión',
+                                                                        c.nombre AS 'Cliente',
+                                                                        u.usuario As 'Cajero',
+                                                                        fc.comentario  As 'Comentario',
+                                                                        f.efectivo_cliente AS 'Efectivo',
+                                                                        f.tarjeta_cliente AS 'Tarjeta',
+                                                                        f.total AS 'Total',
+                                                                        f.tipo_venta AS 'tipo',
+                                                                        f.vuelto  As Vuelto
+                                                                    FROM 
+                                                                        factura f
+                                                                    INNER JOIN 
+                                                                        clientes c ON c.ID = f.ID_Cliente
+                                                                    INNER JOIN
+	                                                                    usuario u  ON u.ID = f.ID_Usuario 
+                                                                    LEFT JOIN 
+	                                                                    factura_comentario fc  ON fc.ID_Factura  =f.ID 
+                                                                    WHERE 
+                                                                        f.fecha_emision >= @fechaInicio
+                                                                        AND f.fecha_emision <  @fechaFin
+                                                                        AND f.cobrada != 0;"
                                           Using cmd As New SQLiteCommand(consulta, db)
                                               cmd.Parameters.AddWithValue("@fechaInicio", fechaInicioFiltrada)
                                               cmd.Parameters.AddWithValue("@fechaFin", fechaFinFiltrada)
@@ -84,17 +100,24 @@ Module Md_Reportes
                                       End Try
                                   End Using
 
-                                  Dim listaVentas As New List(Of Cls_Venta)
+                                  Dim listaVentas As New List(Of Cls_DatosFactura)
                                   If t.Tables.Count > 0 Then
                                       For Each row As DataRow In t.Tables(0).Rows
-                                          Dim numFactura As String = row.Item("# Fact").ToString()
-                                          Dim fecha As Date = Convert.ToDateTime(row.Item("Fecha de emisión"))
-                                          Dim cliente As String = row.Item("Nombre").ToString()
-                                          Dim efectivo As Decimal = Convert.ToDecimal(row.Item("Efectivo"))
-                                          Dim tarjeta As Decimal = Convert.ToDecimal(row.Item("Tarjeta"))
-                                          Dim total As Decimal = Convert.ToDecimal(row.Item("Total"))
+                                          Dim factura As New Cls_DatosFactura With {
+                                            .IdFactura = row.Item("ID").ToString(),
+                                            .NumFactura = row.Item("# Fact").ToString(),
+                                            .Fecha = Convert.ToDateTime(row.Item("Fecha de emisión")),
+                                            .Cliente = row.Item("Cliente").ToString(),
+                                            .Cajero = row.Item("Cajero").ToString(),
+                                            .Comentario = row.Item("Comentario").ToString(),
+                                            .Efectivo = Convert.ToDecimal(row.Item("Efectivo")),
+                                            .Tarjeta = Convert.ToDecimal(row.Item("Tarjeta")),
+                                            .TotalCaja = Convert.ToDecimal(row.Item("Total")),
+                                            .Vuelto = Convert.ToDecimal(row.Item("Vuelto"))
+                                          }
 
-                                          Dim tipoVentaNum As Integer = Convert.ToInt32(row.Item("tipo")) ' <--- OJO: OBTIENES EL NÚMERO
+                                          'Se obtiene el número del tipo de venta
+                                          Dim tipoVentaNum As Integer = Convert.ToInt32(row.Item("tipo"))
                                           Dim tipoVenta As String
 
                                           Select Case tipoVentaNum
@@ -111,9 +134,9 @@ Module Md_Reportes
                                               Case Else
                                                   tipoVenta = "Desconocido"
                                           End Select
-
-                                          Dim venta As New Cls_Venta(numFactura, fecha, cliente, total, tipoVenta, efectivo, tarjeta)
-                                          listaVentas.Add(venta)
+                                          factura.TipoPago = tipoVenta
+                                          'Se añade la factura a la lista
+                                          listaVentas.Add(factura)
                                       Next
                                   End If
                                   Return listaVentas
@@ -200,17 +223,17 @@ Module Md_Reportes
         End If
 
         'Se obtiene la información relacionada con las ventas en la 
-        Dim listaVentas As List(Of Cls_Venta) = Await ObtenerListaVentas(fechaInicio, fechaFin, T)
+        Dim listaVentas As List(Of Cls_DatosFactura) = Await ObtenerListaVentas(fechaInicio, fechaFin, T)
         Dim ventasEfectivo As Decimal = 0
         Dim ventasTarjeta As Decimal = 0
-        For Each venta As Cls_Venta In listaVentas
-            If venta.Tipo_venta = "Efectivo" Then
-                ventasEfectivo += venta.Total
-            ElseIf venta.Tipo_venta = "Mixto" Then
+        For Each venta As Cls_DatosFactura In listaVentas
+            If venta.TipoPago = "Efectivo" Then
+                ventasEfectivo += venta.TotalCaja
+            ElseIf venta.TipoPago = "Mixto" Then
                 ventasEfectivo += venta.Efectivo
                 ventasTarjeta += venta.Tarjeta
             Else
-                ventasTarjeta += venta.Total
+                ventasTarjeta += venta.TotalCaja
             End If
         Next
         Dim infoInicialCierre As New Cls_CierreCaja(fechaInicio, fechaFin, saldoTurnoAnterior, ventasEfectivo, ventasTarjeta)

--- a/SistemaFacturación/P_Caja.vb
+++ b/SistemaFacturación/P_Caja.vb
@@ -230,15 +230,44 @@ Public Class P_Caja
 
 
     Friend Sub AgregarProd(ID As String, codigo As String, nombre As String, precioVenta As String, cant As String)
-        Dim Subtotal As Double = cant * Convert.ToInt32(precioVenta)
-        Dim row As String() = {ID, codigo, nombre, precioVenta, cant, Subtotal}
-        DGV_Caja.Columns(0).Visible = False
-        Dim filaNueva As Integer = DGV_Caja.Rows.Add(row)
+        Dim filaExistente As DataGridViewRow = Nothing
+
+        ' 1. Busca si el producto ya existe en el DataGridView por su ID
+        For Each fila As DataGridViewRow In DGV_Caja.Rows
+            If fila.Cells(0).Value IsNot Nothing AndAlso fila.Cells(0).Value.ToString() = ID Then
+                filaExistente = fila
+                Exit For ' Sal del bucle tan pronto como encuentres la fila
+            End If
+        Next
+
+        If filaExistente IsNot Nothing Then
+            ' 2. Si el producto ya existe, aumenta la cantidad y recalcula el subtotal
+            Dim cantidadActual As Integer = 0
+            If Integer.TryParse(filaExistente.Cells(4).Value.ToString(), cantidadActual) Then
+                cantidadActual += Integer.Parse(cant)
+                filaExistente.Cells(4).Value = cantidadActual.ToString()
+
+                Dim subtotalActual As Double = Convert.ToDouble(filaExistente.Cells(3).Value) * cantidadActual
+                filaExistente.Cells(5).Value = subtotalActual
+            End If
+
+            ' Se coloca la celda de la cantidad para que pueda ser editada en caso de ser necesario
+            DGV_Caja.CurrentCell = filaExistente.Cells(4)
+            DGV_Caja.BeginEdit(True)
+        Else
+            ' 3. Si el producto no existe, agrega una nueva fila como lo hacías antes
+            Dim Subtotal As Double = Convert.ToInt32(cant) * Convert.ToInt32(precioVenta)
+            Dim row As String() = {ID, codigo, nombre, precioVenta, cant, Subtotal.ToString()}
+
+            Dim filaNueva As Integer = DGV_Caja.Rows.Add(row)
+            DGV_Caja.CurrentCell = DGV_Caja.Rows(filaNueva).Cells(4)
+            DGV_Caja.BeginEdit(True)
+        End If
+
+        ' Acciones que se ejecutan en ambos casos
         TXT_BuscarProducto.Clear()
         ValidarListView()
         CargarTotal()
-        DGV_Caja.CurrentCell = DGV_Caja.Rows(filaNueva).Cells(4)
-        DGV_Caja.BeginEdit(True)
     End Sub
 
     Friend Sub CargarTotal()
@@ -294,7 +323,7 @@ Public Class P_Caja
 
     End Sub
 
-    Private Sub DGV_Caja_CellValueChanged(sender As Object, e As DataGridViewCellEventArgs) Handles DGV_Caja.CellValueChanged
+    Private Sub DGV_Caja_CellEndEdit(sender As Object, e As DataGridViewCellEventArgs) Handles DGV_Caja.CellEndEdit
         ' Se asegura de que no estamos en una fila de encabezado o de inserción
         If e.RowIndex >= 0 AndAlso DGV_Caja.Rows(e.RowIndex).Cells(4).Value IsNot Nothing Then
             ' Obtiene los valores de la cantidad y el precio de la fila que se está editando

--- a/SistemaFacturación/P_DatosFactura.vb
+++ b/SistemaFacturación/P_DatosFactura.vb
@@ -1,9 +1,23 @@
 ﻿Public Class P_DatosFactura
     Friend idFact As String
     Private Sub BTN_RegresarPed_Click(sender As Object, e As EventArgs) Handles BTN_RegresarPed.Click
-        P_ReimprimirFact.Show()
-        P_ReimprimirFact.Select()
+        Owner.Select()
         Me.Close()
+    End Sub
+
+    Public Sub CargarDatos(datosFactura As Cls_DatosFactura)
+        Me.idFact = datosFactura.IdFactura
+        Me.TXT_NumFact.Text = datosFactura.NumFactura
+        Me.TXT_FechaEmision.Text = datosFactura.Fecha
+        Me.TXT_Cliente.Text = datosFactura.Cliente
+        Me.TXT_Cajero.Text = datosFactura.Cajero
+        Me.TXT_Comentario.Text = datosFactura.Comentario
+        Me.TXT_Total.Text = datosFactura.TotalCaja
+        Me.TXT_Efectivo.Text = datosFactura.Efectivo
+        Me.TXT_Tarjeta.Text = datosFactura.Tarjeta
+        Me.TXT_Vuelto.Text = datosFactura.Vuelto
+        Me.TXT_TipoPago.Text = datosFactura.TipoPago
+        CargarProds()
     End Sub
 
     Friend Sub CargarProds()
@@ -38,5 +52,9 @@
 
     Private Sub BTN_CerrarApp_Click(sender As Object, e As EventArgs) Handles BTN_CerrarApp.Click
         msgCerrarApp()
+    End Sub
+
+    Private Sub P_DatosFactura_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+
     End Sub
 End Class

--- a/SistemaFacturación/P_ReimprimirFact.vb
+++ b/SistemaFacturación/P_ReimprimirFact.vb
@@ -185,21 +185,29 @@ Public Class P_ReimprimirFact
     End Sub
 
     Private Sub MNU_Datos_Click(sender As Object, e As EventArgs) Handles MNU_Datos.Click
-        P_DatosFactura.idFact = DGV_ReimprimirFact.SelectedRows(0).Cells(0).Value.ToString()
-        P_DatosFactura.TXT_NumFact.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(1).Value.ToString()
-        P_DatosFactura.TXT_FechaEmision.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(2).Value.ToString()
-        P_DatosFactura.TXT_Cliente.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(3).Value.ToString()
-        P_DatosFactura.TXT_Cajero.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(4).Value.ToString()
-        P_DatosFactura.TXT_Comentario.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(5).Value.ToString()
-        P_DatosFactura.TXT_Total.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(6).Value.ToString()
-        P_DatosFactura.TXT_Efectivo.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(7).Value.ToString()
-        P_DatosFactura.TXT_Tarjeta.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(8).Value.ToString()
-        P_DatosFactura.TXT_Vuelto.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(9).Value.ToString()
-        P_DatosFactura.TXT_TipoPago.Text = DGV_ReimprimirFact.SelectedRows(0).Cells(10).Value.ToString()
-        P_DatosFactura.Show()
-        P_DatosFactura.Select()
-        P_DatosFactura.cargarProds()
-        Me.Close()
+        Dim datosFactura As New Cls_DatosFactura With {
+            .IdFactura = DGV_ReimprimirFact.SelectedRows(0).Cells(0).Value.ToString(),
+            .NumFactura = DGV_ReimprimirFact.SelectedRows(0).Cells(1).Value.ToString(),
+            .Fecha = DGV_ReimprimirFact.SelectedRows(0).Cells(2).Value.ToString(),
+            .Cliente = DGV_ReimprimirFact.SelectedRows(0).Cells(3).Value.ToString(),
+            .Cajero = DGV_ReimprimirFact.SelectedRows(0).Cells(4).Value.ToString(),
+            .Comentario = DGV_ReimprimirFact.SelectedRows(0).Cells(5).Value.ToString(),
+            .TotalCaja = DGV_ReimprimirFact.SelectedRows(0).Cells(6).Value.ToString(),
+            .Efectivo = DGV_ReimprimirFact.SelectedRows(0).Cells(7).Value.ToString(),
+            .Tarjeta = DGV_ReimprimirFact.SelectedRows(0).Cells(8).Value.ToString(),
+            .Vuelto = DGV_ReimprimirFact.SelectedRows(0).Cells(9).Value.ToString(),
+            .TipoPago = DGV_ReimprimirFact.SelectedRows(0).Cells(10).Value.ToString()
+        }
+        ' Crea la instancia del formulario
+        Dim frmDatosFactura As New P_DatosFactura With {
+            .Owner = Me
+        }
+
+        ' Llama a la nueva subrutina para cargar los datos en el formulario
+        frmDatosFactura.CargarDatos(datosFactura)
+
+        ' Muestra el formulario
+        frmDatosFactura.Show()
     End Sub
 
 

--- a/SistemaFacturación/P_ReporteVentas.Designer.vb
+++ b/SistemaFacturación/P_ReporteVentas.Designer.vb
@@ -23,14 +23,14 @@ Partial Class P_ReporteVentas
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(P_ReporteVentas))
-        Dim DataGridViewCellStyle57 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle58 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle59 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle60 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle61 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle62 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle63 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle64 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle1 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle2 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle3 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle4 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle5 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle6 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle7 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle8 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Me.TAB_Reportes = New Guna.UI2.WinForms.Guna2TabControl()
         Me.PAG_ReporteVentas = New System.Windows.Forms.TabPage()
         Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel()
@@ -53,12 +53,15 @@ Partial Class P_ReporteVentas
         Me.LBL_Usu = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.TXT_TotalVentas = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2Panel1 = New Guna.UI2.WinForms.Guna2Panel()
-        Me.Guna2Button1 = New Guna.UI2.WinForms.Guna2Button()
+        Me.BTN_GenerarReporteVentaPDF = New Guna.UI2.WinForms.Guna2Button()
         Me.BTN_RegresarReporte = New Guna.UI2.WinForms.Guna2Button()
         Me.BTN_GenReporte = New Guna.UI2.WinForms.Guna2Button()
         Me.DTP_Hasta = New Guna.UI2.WinForms.Guna2DateTimePicker()
         Me.DTP_Desde = New Guna.UI2.WinForms.Guna2DateTimePicker()
         Me.DGV_FactReporte = New Guna.UI2.WinForms.Guna2DataGridView()
+        Me.MNU_CONTX = New Guna.UI2.WinForms.Guna2ContextMenuStrip()
+        Me.MNU_REIMPRIMIR = New System.Windows.Forms.ToolStripMenuItem()
+        Me.MNU_Datos = New System.Windows.Forms.ToolStripMenuItem()
         Me.PAG_ReporteProd = New System.Windows.Forms.TabPage()
         Me.TBL_ReporteProductosGeneral = New System.Windows.Forms.TableLayoutPanel()
         Me.TBL_ResultContainer = New System.Windows.Forms.TableLayoutPanel()
@@ -132,6 +135,11 @@ Partial Class P_ReporteVentas
         Me.BTN_CCLimpiarCierre = New Guna.UI2.WinForms.Guna2Button()
         Me.Guna2HtmlLabel16 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.PAN_Cell2InfoCierre = New Guna.UI2.WinForms.Guna2Panel()
+        Me.TableLayoutPanel4 = New System.Windows.Forms.TableLayoutPanel()
+        Me.Guna2HtmlLabel39 = New Guna.UI2.WinForms.Guna2HtmlLabel()
+        Me.Guna2HtmlLabel33 = New Guna.UI2.WinForms.Guna2HtmlLabel()
+        Me.NUD_SalidasEfectivo = New Guna.UI2.WinForms.Guna2NumericUpDown()
+        Me.TXT_CCTotalEsperado = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2GroupBox5 = New Guna.UI2.WinForms.Guna2GroupBox()
         Me.TableLayoutPanel3 = New System.Windows.Forms.TableLayoutPanel()
         Me.Guna2Panel3 = New Guna.UI2.WinForms.Guna2Panel()
@@ -144,13 +152,10 @@ Partial Class P_ReporteVentas
         Me.Guna2HtmlLabel37 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.NUD_CCSaldoSiguienteTurno = New Guna.UI2.WinForms.Guna2NumericUpDown()
         Me.Guna2HtmlLabel36 = New Guna.UI2.WinForms.Guna2HtmlLabel()
-        Me.NUD_SalidasEfectivo = New Guna.UI2.WinForms.Guna2NumericUpDown()
-        Me.TXT_CCTotalEsperado = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2Panel2 = New Guna.UI2.WinForms.Guna2Panel()
         Me.TableLayoutPanel2 = New System.Windows.Forms.TableLayoutPanel()
         Me.Guna2Button3 = New Guna.UI2.WinForms.Guna2Button()
         Me.BTN_GenerarCierre = New Guna.UI2.WinForms.Guna2Button()
-        Me.Guna2HtmlLabel33 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.Guna2GroupBox4 = New Guna.UI2.WinForms.Guna2GroupBox()
         Me.TXT_CCVentaTarjeta = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel32 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -158,8 +163,8 @@ Partial Class P_ReporteVentas
         Me.Guna2HtmlLabel31 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.TXT_CCSaldoInicial = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel30 = New Guna.UI2.WinForms.Guna2HtmlLabel()
-        Me.TableLayoutPanel4 = New System.Windows.Forms.TableLayoutPanel()
-        Me.Guna2HtmlLabel39 = New Guna.UI2.WinForms.Guna2HtmlLabel()
+        Me.PrintDocument = New System.Drawing.Printing.PrintDocument()
+        Me.PrintDialog = New System.Windows.Forms.PrintDialog()
         Me.TAB_Reportes.SuspendLayout()
         Me.PAG_ReporteVentas.SuspendLayout()
         Me.TableLayoutPanel1.SuspendLayout()
@@ -167,6 +172,7 @@ Partial Class P_ReporteVentas
         Me.Guna2GroupBox2.SuspendLayout()
         Me.Guna2Panel1.SuspendLayout()
         CType(Me.DGV_FactReporte, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.MNU_CONTX.SuspendLayout()
         Me.PAG_ReporteProd.SuspendLayout()
         Me.TBL_ReporteProductosGeneral.SuspendLayout()
         Me.TBL_ResultContainer.SuspendLayout()
@@ -210,16 +216,16 @@ Partial Class P_ReporteVentas
         Me.PAN_FooterEfectivoReal.SuspendLayout()
         Me.PAN_HeaderEfectivoReal.SuspendLayout()
         Me.PAN_Cell2InfoCierre.SuspendLayout()
+        Me.TableLayoutPanel4.SuspendLayout()
+        CType(Me.NUD_SalidasEfectivo, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.Guna2GroupBox5.SuspendLayout()
         Me.TableLayoutPanel3.SuspendLayout()
         Me.Guna2Panel3.SuspendLayout()
         Me.Guna2Panel4.SuspendLayout()
         CType(Me.NUD_CCSaldoSiguienteTurno, System.ComponentModel.ISupportInitialize).BeginInit()
-        CType(Me.NUD_SalidasEfectivo, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.Guna2Panel2.SuspendLayout()
         Me.TableLayoutPanel2.SuspendLayout()
         Me.Guna2GroupBox4.SuspendLayout()
-        Me.TableLayoutPanel4.SuspendLayout()
         Me.SuspendLayout()
         '
         'TAB_Reportes
@@ -614,7 +620,7 @@ Partial Class P_ReporteVentas
         '
         'Guna2Panel1
         '
-        Me.Guna2Panel1.Controls.Add(Me.Guna2Button1)
+        Me.Guna2Panel1.Controls.Add(Me.BTN_GenerarReporteVentaPDF)
         Me.Guna2Panel1.Controls.Add(Me.BTN_RegresarReporte)
         Me.Guna2Panel1.Controls.Add(Me.BTN_GenReporte)
         Me.Guna2Panel1.Dock = System.Windows.Forms.DockStyle.Bottom
@@ -623,24 +629,24 @@ Partial Class P_ReporteVentas
         Me.Guna2Panel1.Size = New System.Drawing.Size(1240, 70)
         Me.Guna2Panel1.TabIndex = 124
         '
-        'Guna2Button1
+        'BTN_GenerarReporteVentaPDF
         '
-        Me.Guna2Button1.BorderColor = System.Drawing.Color.Red
-        Me.Guna2Button1.DisabledState.BorderColor = System.Drawing.Color.DarkGray
-        Me.Guna2Button1.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
-        Me.Guna2Button1.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
-        Me.Guna2Button1.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
-        Me.Guna2Button1.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.Guna2Button1.FillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-        Me.Guna2Button1.Font = New System.Drawing.Font("Ebrima", 20.25!, System.Drawing.FontStyle.Bold)
-        Me.Guna2Button1.ForeColor = System.Drawing.Color.White
-        Me.Guna2Button1.Image = CType(resources.GetObject("Guna2Button1.Image"), System.Drawing.Image)
-        Me.Guna2Button1.ImageSize = New System.Drawing.Size(50, 50)
-        Me.Guna2Button1.Location = New System.Drawing.Point(403, 0)
-        Me.Guna2Button1.Name = "Guna2Button1"
-        Me.Guna2Button1.Size = New System.Drawing.Size(426, 70)
-        Me.Guna2Button1.TabIndex = 84
-        Me.Guna2Button1.Text = "Generar en PDF"
+        Me.BTN_GenerarReporteVentaPDF.BorderColor = System.Drawing.Color.Red
+        Me.BTN_GenerarReporteVentaPDF.DisabledState.BorderColor = System.Drawing.Color.DarkGray
+        Me.BTN_GenerarReporteVentaPDF.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
+        Me.BTN_GenerarReporteVentaPDF.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
+        Me.BTN_GenerarReporteVentaPDF.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
+        Me.BTN_GenerarReporteVentaPDF.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.BTN_GenerarReporteVentaPDF.FillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        Me.BTN_GenerarReporteVentaPDF.Font = New System.Drawing.Font("Ebrima", 20.25!, System.Drawing.FontStyle.Bold)
+        Me.BTN_GenerarReporteVentaPDF.ForeColor = System.Drawing.Color.White
+        Me.BTN_GenerarReporteVentaPDF.Image = CType(resources.GetObject("BTN_GenerarReporteVentaPDF.Image"), System.Drawing.Image)
+        Me.BTN_GenerarReporteVentaPDF.ImageSize = New System.Drawing.Size(50, 50)
+        Me.BTN_GenerarReporteVentaPDF.Location = New System.Drawing.Point(403, 0)
+        Me.BTN_GenerarReporteVentaPDF.Name = "BTN_GenerarReporteVentaPDF"
+        Me.BTN_GenerarReporteVentaPDF.Size = New System.Drawing.Size(426, 70)
+        Me.BTN_GenerarReporteVentaPDF.TabIndex = 84
+        Me.BTN_GenerarReporteVentaPDF.Text = "Generar en PDF"
         '
         'BTN_RegresarReporte
         '
@@ -717,46 +723,47 @@ Partial Class P_ReporteVentas
         Me.DGV_FactReporte.AllowUserToAddRows = False
         Me.DGV_FactReporte.AllowUserToDeleteRows = False
         Me.DGV_FactReporte.AllowUserToResizeRows = False
-        DataGridViewCellStyle57.BackColor = System.Drawing.Color.White
-        DataGridViewCellStyle57.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle57.ForeColor = System.Drawing.SystemColors.ControlText
-        DataGridViewCellStyle57.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
-        DataGridViewCellStyle57.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
-        Me.DGV_FactReporte.AlternatingRowsDefaultCellStyle = DataGridViewCellStyle57
+        DataGridViewCellStyle1.BackColor = System.Drawing.Color.White
+        DataGridViewCellStyle1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.ControlText
+        DataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
+        DataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
+        Me.DGV_FactReporte.AlternatingRowsDefaultCellStyle = DataGridViewCellStyle1
         Me.DGV_FactReporte.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        DataGridViewCellStyle58.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle58.BackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-        DataGridViewCellStyle58.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle58.ForeColor = System.Drawing.Color.White
-        DataGridViewCellStyle58.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-        DataGridViewCellStyle58.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle58.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.DGV_FactReporte.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle58
+        DataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle2.BackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        DataGridViewCellStyle2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle2.ForeColor = System.Drawing.Color.White
+        DataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        DataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.DGV_FactReporte.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle2
         Me.DGV_FactReporte.ColumnHeadersHeight = 20
-        DataGridViewCellStyle59.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle59.BackColor = System.Drawing.Color.White
-        DataGridViewCellStyle59.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle59.ForeColor = System.Drawing.SystemColors.ControlText
-        DataGridViewCellStyle59.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
-        DataGridViewCellStyle59.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
-        DataGridViewCellStyle59.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
-        Me.DGV_FactReporte.DefaultCellStyle = DataGridViewCellStyle59
+        Me.DGV_FactReporte.ContextMenuStrip = Me.MNU_CONTX
+        DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle3.BackColor = System.Drawing.Color.White
+        DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.ControlText
+        DataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
+        DataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
+        DataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
+        Me.DGV_FactReporte.DefaultCellStyle = DataGridViewCellStyle3
         Me.DGV_FactReporte.GridColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
         Me.DGV_FactReporte.Location = New System.Drawing.Point(22, 188)
         Me.DGV_FactReporte.MultiSelect = False
         Me.DGV_FactReporte.Name = "DGV_FactReporte"
         Me.DGV_FactReporte.ReadOnly = True
         Me.DGV_FactReporte.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None
-        DataGridViewCellStyle60.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle60.BackColor = System.Drawing.Color.White
-        DataGridViewCellStyle60.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle60.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle60.SelectionBackColor = System.Drawing.Color.White
-        DataGridViewCellStyle60.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle60.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.DGV_FactReporte.RowHeadersDefaultCellStyle = DataGridViewCellStyle60
+        DataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle4.BackColor = System.Drawing.Color.White
+        DataGridViewCellStyle4.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle4.SelectionBackColor = System.Drawing.Color.White
+        DataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.DGV_FactReporte.RowHeadersDefaultCellStyle = DataGridViewCellStyle4
         Me.DGV_FactReporte.RowHeadersVisible = False
         Me.DGV_FactReporte.Size = New System.Drawing.Size(898, 409)
         Me.DGV_FactReporte.TabIndex = 121
@@ -781,6 +788,42 @@ Partial Class P_ReporteVentas
         Me.DGV_FactReporte.ThemeStyle.RowsStyle.Height = 22
         Me.DGV_FactReporte.ThemeStyle.RowsStyle.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
         Me.DGV_FactReporte.ThemeStyle.RowsStyle.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
+        '
+        'MNU_CONTX
+        '
+        Me.MNU_CONTX.ImageScalingSize = New System.Drawing.Size(20, 20)
+        Me.MNU_CONTX.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.MNU_REIMPRIMIR, Me.MNU_Datos})
+        Me.MNU_CONTX.Name = "MNU_CONTX"
+        Me.MNU_CONTX.RenderStyle.ArrowColor = System.Drawing.Color.FromArgb(CType(CType(151, Byte), Integer), CType(CType(143, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.MNU_CONTX.RenderStyle.BorderColor = System.Drawing.Color.Gainsboro
+        Me.MNU_CONTX.RenderStyle.ColorTable = Nothing
+        Me.MNU_CONTX.RenderStyle.RoundedEdges = True
+        Me.MNU_CONTX.RenderStyle.SelectionArrowColor = System.Drawing.Color.White
+        Me.MNU_CONTX.RenderStyle.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(100, Byte), Integer), CType(CType(88, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.MNU_CONTX.RenderStyle.SelectionForeColor = System.Drawing.Color.White
+        Me.MNU_CONTX.RenderStyle.SeparatorColor = System.Drawing.Color.Gainsboro
+        Me.MNU_CONTX.RenderStyle.TextRenderingHint = System.Drawing.Text.TextRenderingHint.SystemDefault
+        Me.MNU_CONTX.Size = New System.Drawing.Size(185, 78)
+        '
+        'MNU_REIMPRIMIR
+        '
+        Me.MNU_REIMPRIMIR.BackColor = System.Drawing.SystemColors.HotTrack
+        Me.MNU_REIMPRIMIR.Font = New System.Drawing.Font("Segoe UI Semibold", 9.75!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.MNU_REIMPRIMIR.ForeColor = System.Drawing.SystemColors.Control
+        Me.MNU_REIMPRIMIR.Image = CType(resources.GetObject("MNU_REIMPRIMIR.Image"), System.Drawing.Image)
+        Me.MNU_REIMPRIMIR.Name = "MNU_REIMPRIMIR"
+        Me.MNU_REIMPRIMIR.Size = New System.Drawing.Size(184, 26)
+        Me.MNU_REIMPRIMIR.Text = "Reimprimir"
+        '
+        'MNU_Datos
+        '
+        Me.MNU_Datos.BackColor = System.Drawing.Color.DarkGoldenrod
+        Me.MNU_Datos.Font = New System.Drawing.Font("Segoe UI Semibold", 9.75!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.MNU_Datos.ForeColor = System.Drawing.SystemColors.ButtonHighlight
+        Me.MNU_Datos.Image = CType(resources.GetObject("MNU_Datos.Image"), System.Drawing.Image)
+        Me.MNU_Datos.Name = "MNU_Datos"
+        Me.MNU_Datos.Size = New System.Drawing.Size(184, 26)
+        Me.MNU_Datos.Text = "Ver datos"
         '
         'PAG_ReporteProd
         '
@@ -869,29 +912,29 @@ Partial Class P_ReporteVentas
         Me.DGV_ListProductosMasVendidos.AllowUserToAddRows = False
         Me.DGV_ListProductosMasVendidos.AllowUserToDeleteRows = False
         Me.DGV_ListProductosMasVendidos.AllowUserToResizeRows = False
-        DataGridViewCellStyle61.BackColor = System.Drawing.Color.White
-        DataGridViewCellStyle61.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle61.ForeColor = System.Drawing.SystemColors.ControlText
-        DataGridViewCellStyle61.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
-        DataGridViewCellStyle61.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
-        Me.DGV_ListProductosMasVendidos.AlternatingRowsDefaultCellStyle = DataGridViewCellStyle61
-        DataGridViewCellStyle62.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle62.BackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-        DataGridViewCellStyle62.Font = New System.Drawing.Font("Segoe UI", 18.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle62.ForeColor = System.Drawing.Color.White
-        DataGridViewCellStyle62.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-        DataGridViewCellStyle62.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle62.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.DGV_ListProductosMasVendidos.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle62
+        DataGridViewCellStyle5.BackColor = System.Drawing.Color.White
+        DataGridViewCellStyle5.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.ControlText
+        DataGridViewCellStyle5.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
+        DataGridViewCellStyle5.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
+        Me.DGV_ListProductosMasVendidos.AlternatingRowsDefaultCellStyle = DataGridViewCellStyle5
+        DataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle6.BackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        DataGridViewCellStyle6.Font = New System.Drawing.Font("Segoe UI", 18.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle6.ForeColor = System.Drawing.Color.White
+        DataGridViewCellStyle6.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        DataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.DGV_ListProductosMasVendidos.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle6
         Me.DGV_ListProductosMasVendidos.ColumnHeadersHeight = 20
-        DataGridViewCellStyle63.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle63.BackColor = System.Drawing.Color.White
-        DataGridViewCellStyle63.Font = New System.Drawing.Font("Segoe UI", 18.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle63.ForeColor = System.Drawing.Color.White
-        DataGridViewCellStyle63.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
-        DataGridViewCellStyle63.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
-        DataGridViewCellStyle63.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
-        Me.DGV_ListProductosMasVendidos.DefaultCellStyle = DataGridViewCellStyle63
+        DataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle7.BackColor = System.Drawing.Color.White
+        DataGridViewCellStyle7.Font = New System.Drawing.Font("Segoe UI", 18.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle7.ForeColor = System.Drawing.Color.White
+        DataGridViewCellStyle7.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
+        DataGridViewCellStyle7.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
+        DataGridViewCellStyle7.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
+        Me.DGV_ListProductosMasVendidos.DefaultCellStyle = DataGridViewCellStyle7
         Me.DGV_ListProductosMasVendidos.Dock = System.Windows.Forms.DockStyle.Fill
         Me.DGV_ListProductosMasVendidos.GridColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
         Me.DGV_ListProductosMasVendidos.Location = New System.Drawing.Point(0, 40)
@@ -899,14 +942,14 @@ Partial Class P_ReporteVentas
         Me.DGV_ListProductosMasVendidos.Name = "DGV_ListProductosMasVendidos"
         Me.DGV_ListProductosMasVendidos.ReadOnly = True
         Me.DGV_ListProductosMasVendidos.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None
-        DataGridViewCellStyle64.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle64.BackColor = System.Drawing.Color.White
-        DataGridViewCellStyle64.Font = New System.Drawing.Font("Segoe UI", 18.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle64.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle64.SelectionBackColor = System.Drawing.Color.White
-        DataGridViewCellStyle64.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle64.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.DGV_ListProductosMasVendidos.RowHeadersDefaultCellStyle = DataGridViewCellStyle64
+        DataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle8.BackColor = System.Drawing.Color.White
+        DataGridViewCellStyle8.Font = New System.Drawing.Font("Segoe UI", 18.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle8.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle8.SelectionBackColor = System.Drawing.Color.White
+        DataGridViewCellStyle8.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle8.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.DGV_ListProductosMasVendidos.RowHeadersDefaultCellStyle = DataGridViewCellStyle8
         Me.DGV_ListProductosMasVendidos.RowHeadersVisible = False
         Me.DGV_ListProductosMasVendidos.Size = New System.Drawing.Size(837, 409)
         Me.DGV_ListProductosMasVendidos.TabIndex = 122
@@ -1908,6 +1951,94 @@ Partial Class P_ReporteVentas
         Me.PAN_Cell2InfoCierre.Size = New System.Drawing.Size(614, 694)
         Me.PAN_Cell2InfoCierre.TabIndex = 1
         '
+        'TableLayoutPanel4
+        '
+        Me.TableLayoutPanel4.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.TableLayoutPanel4.ColumnCount = 2
+        Me.TableLayoutPanel4.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
+        Me.TableLayoutPanel4.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
+        Me.TableLayoutPanel4.Controls.Add(Me.Guna2HtmlLabel39, 1, 0)
+        Me.TableLayoutPanel4.Controls.Add(Me.Guna2HtmlLabel33, 0, 0)
+        Me.TableLayoutPanel4.Controls.Add(Me.NUD_SalidasEfectivo, 0, 1)
+        Me.TableLayoutPanel4.Controls.Add(Me.TXT_CCTotalEsperado, 1, 1)
+        Me.TableLayoutPanel4.Location = New System.Drawing.Point(12, 190)
+        Me.TableLayoutPanel4.Name = "TableLayoutPanel4"
+        Me.TableLayoutPanel4.RowCount = 2
+        Me.TableLayoutPanel4.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 43.90244!))
+        Me.TableLayoutPanel4.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 56.09756!))
+        Me.TableLayoutPanel4.Size = New System.Drawing.Size(587, 82)
+        Me.TableLayoutPanel4.TabIndex = 166
+        '
+        'Guna2HtmlLabel39
+        '
+        Me.Guna2HtmlLabel39.AutoSize = False
+        Me.Guna2HtmlLabel39.BackColor = System.Drawing.Color.Transparent
+        Me.Guna2HtmlLabel39.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.Guna2HtmlLabel39.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Guna2HtmlLabel39.ForeColor = System.Drawing.SystemColors.Control
+        Me.Guna2HtmlLabel39.Location = New System.Drawing.Point(296, 3)
+        Me.Guna2HtmlLabel39.Name = "Guna2HtmlLabel39"
+        Me.Guna2HtmlLabel39.Size = New System.Drawing.Size(288, 30)
+        Me.Guna2HtmlLabel39.TabIndex = 158
+        Me.Guna2HtmlLabel39.Text = "Total esperado:"
+        Me.Guna2HtmlLabel39.TextAlignment = System.Drawing.ContentAlignment.MiddleCenter
+        Me.Guna2HtmlLabel39.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
+        '
+        'Guna2HtmlLabel33
+        '
+        Me.Guna2HtmlLabel33.AutoSize = False
+        Me.Guna2HtmlLabel33.BackColor = System.Drawing.Color.Transparent
+        Me.Guna2HtmlLabel33.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.Guna2HtmlLabel33.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Guna2HtmlLabel33.ForeColor = System.Drawing.SystemColors.Control
+        Me.Guna2HtmlLabel33.Location = New System.Drawing.Point(3, 3)
+        Me.Guna2HtmlLabel33.Name = "Guna2HtmlLabel33"
+        Me.Guna2HtmlLabel33.Size = New System.Drawing.Size(287, 30)
+        Me.Guna2HtmlLabel33.TabIndex = 154
+        Me.Guna2HtmlLabel33.Text = "Salidas en efectivo:"
+        Me.Guna2HtmlLabel33.TextAlignment = System.Drawing.ContentAlignment.MiddleCenter
+        Me.Guna2HtmlLabel33.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
+        '
+        'NUD_SalidasEfectivo
+        '
+        Me.NUD_SalidasEfectivo.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.NUD_SalidasEfectivo.BackColor = System.Drawing.Color.Transparent
+        Me.NUD_SalidasEfectivo.BorderRadius = 10
+        Me.NUD_SalidasEfectivo.Cursor = System.Windows.Forms.Cursors.IBeam
+        Me.NUD_SalidasEfectivo.Font = New System.Drawing.Font("Segoe UI", 9.0!)
+        Me.NUD_SalidasEfectivo.Location = New System.Drawing.Point(3, 39)
+        Me.NUD_SalidasEfectivo.Maximum = New Decimal(New Integer() {100000000, 0, 0, 0})
+        Me.NUD_SalidasEfectivo.Name = "NUD_SalidasEfectivo"
+        Me.NUD_SalidasEfectivo.Size = New System.Drawing.Size(287, 36)
+        Me.NUD_SalidasEfectivo.TabIndex = 161
+        Me.NUD_SalidasEfectivo.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        '
+        'TXT_CCTotalEsperado
+        '
+        Me.TXT_CCTotalEsperado.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.TXT_CCTotalEsperado.BorderRadius = 10
+        Me.TXT_CCTotalEsperado.Cursor = System.Windows.Forms.Cursors.IBeam
+        Me.TXT_CCTotalEsperado.DefaultText = ""
+        Me.TXT_CCTotalEsperado.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+        Me.TXT_CCTotalEsperado.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+        Me.TXT_CCTotalEsperado.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_CCTotalEsperado.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_CCTotalEsperado.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_CCTotalEsperado.Font = New System.Drawing.Font("Segoe UI", 9.0!)
+        Me.TXT_CCTotalEsperado.ForeColor = System.Drawing.Color.Black
+        Me.TXT_CCTotalEsperado.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_CCTotalEsperado.IconRightSize = New System.Drawing.Size(40, 40)
+        Me.TXT_CCTotalEsperado.Location = New System.Drawing.Point(296, 39)
+        Me.TXT_CCTotalEsperado.Name = "TXT_CCTotalEsperado"
+        Me.TXT_CCTotalEsperado.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
+        Me.TXT_CCTotalEsperado.PlaceholderText = ""
+        Me.TXT_CCTotalEsperado.ReadOnly = True
+        Me.TXT_CCTotalEsperado.SelectedText = ""
+        Me.TXT_CCTotalEsperado.Size = New System.Drawing.Size(288, 36)
+        Me.TXT_CCTotalEsperado.TabIndex = 158
+        '
         'Guna2GroupBox5
         '
         Me.Guna2GroupBox5.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
@@ -2099,45 +2230,6 @@ Partial Class P_ReporteVentas
         Me.Guna2HtmlLabel36.Text = "Saldo siguiente turno:"
         Me.Guna2HtmlLabel36.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
         '
-        'NUD_SalidasEfectivo
-        '
-        Me.NUD_SalidasEfectivo.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
-            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.NUD_SalidasEfectivo.BackColor = System.Drawing.Color.Transparent
-        Me.NUD_SalidasEfectivo.BorderRadius = 10
-        Me.NUD_SalidasEfectivo.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.NUD_SalidasEfectivo.Font = New System.Drawing.Font("Segoe UI", 9.0!)
-        Me.NUD_SalidasEfectivo.Location = New System.Drawing.Point(3, 39)
-        Me.NUD_SalidasEfectivo.Maximum = New Decimal(New Integer() {100000000, 0, 0, 0})
-        Me.NUD_SalidasEfectivo.Name = "NUD_SalidasEfectivo"
-        Me.NUD_SalidasEfectivo.Size = New System.Drawing.Size(287, 36)
-        Me.NUD_SalidasEfectivo.TabIndex = 161
-        Me.NUD_SalidasEfectivo.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-        '
-        'TXT_CCTotalEsperado
-        '
-        Me.TXT_CCTotalEsperado.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.TXT_CCTotalEsperado.BorderRadius = 10
-        Me.TXT_CCTotalEsperado.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.TXT_CCTotalEsperado.DefaultText = ""
-        Me.TXT_CCTotalEsperado.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
-        Me.TXT_CCTotalEsperado.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
-        Me.TXT_CCTotalEsperado.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-        Me.TXT_CCTotalEsperado.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-        Me.TXT_CCTotalEsperado.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-        Me.TXT_CCTotalEsperado.Font = New System.Drawing.Font("Segoe UI", 9.0!)
-        Me.TXT_CCTotalEsperado.ForeColor = System.Drawing.Color.Black
-        Me.TXT_CCTotalEsperado.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-        Me.TXT_CCTotalEsperado.IconRightSize = New System.Drawing.Size(40, 40)
-        Me.TXT_CCTotalEsperado.Location = New System.Drawing.Point(296, 39)
-        Me.TXT_CCTotalEsperado.Name = "TXT_CCTotalEsperado"
-        Me.TXT_CCTotalEsperado.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
-        Me.TXT_CCTotalEsperado.PlaceholderText = ""
-        Me.TXT_CCTotalEsperado.ReadOnly = True
-        Me.TXT_CCTotalEsperado.SelectedText = ""
-        Me.TXT_CCTotalEsperado.Size = New System.Drawing.Size(288, 36)
-        Me.TXT_CCTotalEsperado.TabIndex = 158
-        '
         'Guna2Panel2
         '
         Me.Guna2Panel2.Controls.Add(Me.TableLayoutPanel2)
@@ -2202,21 +2294,6 @@ Partial Class P_ReporteVentas
         Me.BTN_GenerarCierre.Size = New System.Drawing.Size(301, 60)
         Me.BTN_GenerarCierre.TabIndex = 151
         Me.BTN_GenerarCierre.Text = "Generar Cierre"
-        '
-        'Guna2HtmlLabel33
-        '
-        Me.Guna2HtmlLabel33.AutoSize = False
-        Me.Guna2HtmlLabel33.BackColor = System.Drawing.Color.Transparent
-        Me.Guna2HtmlLabel33.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.Guna2HtmlLabel33.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.Guna2HtmlLabel33.ForeColor = System.Drawing.SystemColors.Control
-        Me.Guna2HtmlLabel33.Location = New System.Drawing.Point(3, 3)
-        Me.Guna2HtmlLabel33.Name = "Guna2HtmlLabel33"
-        Me.Guna2HtmlLabel33.Size = New System.Drawing.Size(287, 30)
-        Me.Guna2HtmlLabel33.TabIndex = 154
-        Me.Guna2HtmlLabel33.Text = "Salidas en efectivo:"
-        Me.Guna2HtmlLabel33.TextAlignment = System.Drawing.ContentAlignment.MiddleCenter
-        Me.Guna2HtmlLabel33.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
         '
         'Guna2GroupBox4
         '
@@ -2353,39 +2430,12 @@ Partial Class P_ReporteVentas
         Me.Guna2HtmlLabel30.Text = "Saldo inicial:"
         Me.Guna2HtmlLabel30.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
         '
-        'TableLayoutPanel4
+        'PrintDocument
         '
-        Me.TableLayoutPanel4.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
-            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.TableLayoutPanel4.ColumnCount = 2
-        Me.TableLayoutPanel4.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
-        Me.TableLayoutPanel4.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
-        Me.TableLayoutPanel4.Controls.Add(Me.Guna2HtmlLabel39, 1, 0)
-        Me.TableLayoutPanel4.Controls.Add(Me.Guna2HtmlLabel33, 0, 0)
-        Me.TableLayoutPanel4.Controls.Add(Me.NUD_SalidasEfectivo, 0, 1)
-        Me.TableLayoutPanel4.Controls.Add(Me.TXT_CCTotalEsperado, 1, 1)
-        Me.TableLayoutPanel4.Location = New System.Drawing.Point(12, 190)
-        Me.TableLayoutPanel4.Name = "TableLayoutPanel4"
-        Me.TableLayoutPanel4.RowCount = 2
-        Me.TableLayoutPanel4.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 43.90244!))
-        Me.TableLayoutPanel4.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 56.09756!))
-        Me.TableLayoutPanel4.Size = New System.Drawing.Size(587, 82)
-        Me.TableLayoutPanel4.TabIndex = 166
         '
-        'Guna2HtmlLabel39
+        'PrintDialog
         '
-        Me.Guna2HtmlLabel39.AutoSize = False
-        Me.Guna2HtmlLabel39.BackColor = System.Drawing.Color.Transparent
-        Me.Guna2HtmlLabel39.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.Guna2HtmlLabel39.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.Guna2HtmlLabel39.ForeColor = System.Drawing.SystemColors.Control
-        Me.Guna2HtmlLabel39.Location = New System.Drawing.Point(296, 3)
-        Me.Guna2HtmlLabel39.Name = "Guna2HtmlLabel39"
-        Me.Guna2HtmlLabel39.Size = New System.Drawing.Size(288, 30)
-        Me.Guna2HtmlLabel39.TabIndex = 158
-        Me.Guna2HtmlLabel39.Text = "Total esperado:"
-        Me.Guna2HtmlLabel39.TextAlignment = System.Drawing.ContentAlignment.MiddleCenter
-        Me.Guna2HtmlLabel39.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
+        Me.PrintDialog.UseEXDialog = True
         '
         'P_ReporteVentas
         '
@@ -2409,6 +2459,7 @@ Partial Class P_ReporteVentas
         Me.Guna2GroupBox2.PerformLayout()
         Me.Guna2Panel1.ResumeLayout(False)
         CType(Me.DGV_FactReporte, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.MNU_CONTX.ResumeLayout(False)
         Me.PAG_ReporteProd.ResumeLayout(False)
         Me.TBL_ReporteProductosGeneral.ResumeLayout(False)
         Me.TBL_ResultContainer.ResumeLayout(False)
@@ -2469,6 +2520,8 @@ Partial Class P_ReporteVentas
         Me.PAN_HeaderEfectivoReal.PerformLayout()
         Me.PAN_Cell2InfoCierre.ResumeLayout(False)
         Me.PAN_Cell2InfoCierre.PerformLayout()
+        Me.TableLayoutPanel4.ResumeLayout(False)
+        CType(Me.NUD_SalidasEfectivo, System.ComponentModel.ISupportInitialize).EndInit()
         Me.Guna2GroupBox5.ResumeLayout(False)
         Me.TableLayoutPanel3.ResumeLayout(False)
         Me.Guna2Panel3.ResumeLayout(False)
@@ -2476,12 +2529,10 @@ Partial Class P_ReporteVentas
         Me.Guna2Panel4.ResumeLayout(False)
         Me.Guna2Panel4.PerformLayout()
         CType(Me.NUD_CCSaldoSiguienteTurno, System.ComponentModel.ISupportInitialize).EndInit()
-        CType(Me.NUD_SalidasEfectivo, System.ComponentModel.ISupportInitialize).EndInit()
         Me.Guna2Panel2.ResumeLayout(False)
         Me.TableLayoutPanel2.ResumeLayout(False)
         Me.Guna2GroupBox4.ResumeLayout(False)
         Me.Guna2GroupBox4.PerformLayout()
-        Me.TableLayoutPanel4.ResumeLayout(False)
         Me.ResumeLayout(False)
 
     End Sub
@@ -2498,7 +2549,7 @@ Partial Class P_ReporteVentas
     Friend WithEvents DTP_Hasta As Guna.UI2.WinForms.Guna2DateTimePicker
     Friend WithEvents DTP_Desde As Guna.UI2.WinForms.Guna2DateTimePicker
     Friend WithEvents DGV_FactReporte As Guna.UI2.WinForms.Guna2DataGridView
-    Friend WithEvents Guna2Button1 As Guna.UI2.WinForms.Guna2Button
+    Friend WithEvents BTN_GenerarReporteVentaPDF As Guna.UI2.WinForms.Guna2Button
     Friend WithEvents Guna2HtmlLabel3 As Guna.UI2.WinForms.Guna2HtmlLabel
     Friend WithEvents TXT_VentasEfectivo As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel4 As Guna.UI2.WinForms.Guna2HtmlLabel
@@ -2614,4 +2665,9 @@ Partial Class P_ReporteVentas
     Friend WithEvents Guna2Panel4 As Guna.UI2.WinForms.Guna2Panel
     Friend WithEvents TableLayoutPanel4 As TableLayoutPanel
     Friend WithEvents Guna2HtmlLabel39 As Guna.UI2.WinForms.Guna2HtmlLabel
+    Friend WithEvents MNU_CONTX As Guna.UI2.WinForms.Guna2ContextMenuStrip
+    Friend WithEvents MNU_REIMPRIMIR As ToolStripMenuItem
+    Friend WithEvents MNU_Datos As ToolStripMenuItem
+    Friend WithEvents PrintDocument As Printing.PrintDocument
+    Friend WithEvents PrintDialog As PrintDialog
 End Class

--- a/SistemaFacturación/P_ReporteVentas.resx
+++ b/SistemaFacturación/P_ReporteVentas.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="Guna2Button1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="BTN_GenerarReporteVentaPDF.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAfQAAAH0CAYAAADL1t+KAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
         vAAADrwBlbxySQAAJ0JJREFUeF7t3Qm0ZVlZH3Doru4GmmYeRHBgVjFBUVQgi4SlCQnoisGoKI6oLJcr
@@ -561,6 +561,293 @@
         QmCC
 </value>
   </data>
+  <metadata name="MNU_CONTX.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="MNU_REIMPRIMIR.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAfQAAAH0CAYAAADL1t+KAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAGvRJREFUeF7t3XvQtWtdF3C1A7I3KorOAG0EVHImT1mUjKAioCialHlAzMMIFGoa
+        HlEyy6YMLUEwDBAYzQOUYhCK5RSClJZJxEEEMRUVxDzRBEqT+G3W9mFm+3Uv3vU+z33f17rW+nxm1j97
+        v+99Xc/z+13X972fZ13rfqd3AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDVJPmY
+        JN+Q5EWB47Lryb+f5KO6bwH4wxD/nCQ/kuQtvYPCkXpzkucl+azuZ4Czk+ReSV7SOyVM5sVJPrT7G+Dk
+        JXmPJE/pXREm9/gkt+1+BzhJSR6Q5H/1Tggn4nVJ/nL3PcBJSfJ5vfvBCdq9F+QTuv8BTkKSByV5W+98
+        cKLemuSevQ4Appbkg72DnTP060nu1OsBYEpJbpfkf/ZOB2fiRb0mAKaU5Jt7h4Mz87BeFwBTSXK33tng
+        DL3RcTZgakme2jsbnKm/0+sDYApJ3qd3NDhjr+s1AjCFJF/ZOxqcuY/rdQJw9JL8ZO9mcOae1OsE4Kgl
+        edck/693Mzhzr+i1AnDUkty7dzLgZrfp9QJwtHbnbnsXA272Qb1eAI5Wkq/pXQy42Sf3egE4Wkke07sY
+        cLNH9noBOFru0GGvR/d6AThaAh32EujAPAQ67CXQgXkIdNhLoAPzEOiwl0AH5iHQYS+BDsxDoMNeAh2Y
+        h0CHvQQ6MA+BDnsJdGAeAh32EujAPAQ67CXQgXkIdNhLoAPzEOiwl0AH5iHQYS+BDsxDoMNeAh2Yh0CH
+        vQQ6MA+BDnsJdGAeAh32EujAPAQ67CXQgXkIdNhLoAPzEOiwl0AH5iHQYS+BDsxDoMNeAh2Yh0CHvQQ6
+        MA+BDnsJdGAeAh32EujAPAQ67CXQgXkIdNhLoAPzEOiwl0AH5iHQYS+BDsxDoMNeAh2Yh0CHvQQ6MA+B
+        DnsJdGAeAh32EujAPAQ67CXQgXkIdNhLoAPzEOiwl0AH5iHQYS+BDsxDoMNeAh2Yh0CHvQQ6nKMkNyV5
+        eJLvSfKrvTNs5MN7Xtci0GGvr+r1ci1J7tkX2chuz9ntPV+Q5M49L+Aaktw1yROSvLZX1yB/oed4LQId
+        9vrqXi/XMjDQ22uSPH53o9FzBG4hyQ1JvrFX0BEQ6LCcmQP9lr6u5wn84YJ9cJI39Io5EgIdlnMqgb7z
+        S0nu3/OFs3RxV/6sXiVHRqDDck4p0N/uyT1nOCtJ3jvJS3tlHCFvioPlzPSmuOvxY0lu7LnDyUty2yQv
+        6RVxpP5iz/9aBDrsdd3H1iYJ9J0fTfIuPX84aUme3SvhiLlDh+Wc6h362z225w8nK8mjegUcOYEOyzn1
+        QN/5pP4a4OQkuVOSt3b3Hzk/coflnPKP3N/u9Ulu018HnJSLT12ajXe5w3JO8V3ut+Yx/XXAyUhyjyRv
+        666fgDt0WM453KHv/Pbuzb/9tcBJSPKk7vhJ+B06LOccfof+do/srwWmt/t9UpK3dLdPwh06LOdc7tB3
+        XtJfC0zv4qNdZyXQYTnnFOg7ntLGabl4QtGsBDos59wC/bP764GpJXlxd/lEBDos59wC/Vv664GpJfmN
+        7vKJCHRYzrkF+vP664GpdYdPRqDDcs4t0F/ZXw9Ma/ewgu7wyQh0WM65Bfqb+uuBqXWHT8Y5dFjOOZ1D
+        v1l/PTC1bvDJuEOH5ZzbHbpA57R0g09GoMNyBDrMrBt8MgIdliPQYWbd4JMR6LAcgQ4z6wafjECH5Qh0
+        mFk3+GQEOixHoMPMusEnI9BhOQIdZtYNPhmBDssR6DCzbvDJCHRYjkCHmXWDT0agw3IEOsysG3wyAh2W
+        I9BhZt3gkxHosByBDjPrBp+MQIflCHSYWTf4ZAQ6LEegw8y6wScj0GE5Ah1m1g0+GYEOyxHoMLNu8MkI
+        dFiOQIeZdYNPRqDDcgQ6zKwbfDICHZYj0GFm3eCTEeiwHIEOM+sGn4xAh+UIdJhZN/hkBDosR6DDzLrB
+        JyPQYTkCHWbWDT4ZgQ7LEegws27wyQh0WI5Ah5l1g09GoMNyBDrMrBt8MgIdliPQYWbd4JMR6LAcgQ4z
+        6wafjECH5Qh0mFk3+GQEOixHoMPMusEnI9BhOQIdZtYNPhmBDssR6DCzbvDJCHRYjkCHmXWDT0agw3IE
+        OsysG3wyAh2WI9BhZt3gkxHosByBDjPrBp+MQIflCHSYWTf4ZAQ6LEegw8y6wScj0GE5Ah1m1g0+GYEO
+        yxHoMLNu8MkIdFiOQIeZdYNPRqDDcgQ6zKwbfDICHZYj0GFm3eCTEeiwHIEOM+sGn4xAh+UIdJhZkhdO
+        /LpHfz3XkuSht3IdLy+v5CG9Xq4lyQfeynVmeb2gvx4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4FBJ
+        bkry8CTfneRX+rF/AByt3Z79L5N8QZI79/7OGUhy1yRPSPLa7g4ApvWaJI/f3aj1vs+JSXJDkm/sDgDg
+        5HxdZwAnIsmDk7yhKw7AyfqlJPfvPGBSF3flz+oqA3A2ntzZwGSSvHeSl3ZlATg7P5bkxs4JJpDktkle
+        0hUF4Gz9aJJ36bzgyCV5dlcSgLP32M4LjliSR3UFAeDCJ3VucISS3CnJW7t6AHDh9Ulu0/nBkUnyPV05
+        ACiP6fzgiCS5R5K3ddUAoPz27s3TnSMciSRP6ooBwB6P7BzhCOx+H5LkLV0tANjjJZ0lHIGLj3YFgOvh
+        KW3H5uIJOwBwPT6784TBkry4qwQA1/AtnScMluQ3ukoAcA3P6zxhsK4QABzgFZ0nDNYVAoAD/E7nCYN1
+        hQDY1JuTfH+Sr0zykCT3SXK3W+zRd7/4b7v/t/szuwdoHcVR4z+aJgzXBQJgdb+b5LuSPKj35EMl+ZQk
+        39kX3lLPicG6QACs6lm7h2H1XnxZSW5K8oM9yBZ6LgzWBQJgFa/e/ei89+ClJHlAkl/oQdfUc2CwLhAA
+        i/uJJO/W++/SktwhyX/vwdfS4zNYFwiART1ny2eIJ7kxyQt6EmvosRmsCwTAYn6o99ytJHlRT2ZpPSaD
+        dYEAWMSvJXnP3nO3kuQuSf53T2pJPSaDdYEAuLI/SPLRvd9uLcmn98SW1OMxWBcIgCt7eu+1o+x+7N+T
+        W0qPxWBdIACu7AN7rx0lyf16ckvpsRisCwTAlfxo77OjJXlVT3IJPQ6DdYEAuJJP7H12tCQP60kuocdh
+        sC4QAJf25t5jr1eSeyf52ouPc/1XSR6d5F79565HkvfpiS6hx2GwLhAAl/b83mMPleQ9LgJ8n92DWG7s
+        v3eoJC/rC15Vj8FgXSAALu3Le489xMUd9Gv7YrfilUlu13//EEke3xe7qh6DwbpAAFzapR6+kuQ/9IXe
+        gWf23z/ExfPUF9VjMFgXCIBLu0fvsdeS5OP6Igf4kL7OtSS5f1/kqnoMBusCAXBpt+899lqSfGtf5ACP
+        7utcS5IP64tcVY/BYF0gAC7lD3p/PUSS7+sLHeApfZ1rSXJTX+SqegwG6wIBcCmXDfRn9IUO8B19nWsR
+        6GegCwTApb1777HXkuSr+iIHeFRf51qS/Pm+yFX1GAzWBQLg0t6/99hr2b2Rri9ygLv2da4lyQP7IlfV
+        YzBYFwiAS7vUJ7ol+f6+0DvwjP77h0jyOX2hq+oxGKwLBMClfUnvsYdI8l5Jfr4vditenuTd+u8fIsm3
+        9cWuqsdgsC4QAJf2nN5jD3Xx0a/P7gvewlOT3NB/71BJfrYveFU9BoN1gQC4tDf1Hnu9ktw3yWMuHs7y
+        zIs3zd2z/9z1SHKnnugSehwG6wIBcCUf2/vsaEm+uCe5hB6HwbpAAFzJpX/svoYk75zkF3qSS+ixGKwL
+        BMCV/EGS9+u9dpQkn9wTXEqPxWBdIACu7Am9146S5IU9uaX0WAzWBQLgyt522TPpS0ry8J7Ykno8BusC
+        AbCIX05yY++5W0nyZ5P8Xk9qST0mg3WBAFjM9/Weu4Ukt03y0p7M0npcBusCAbCo70zyJ3vvXcvFB9T8
+        t57EGnpsBusCAbC4f7+7a+79d2lJ7pjk1T34Wnp8BusCAbCKn07yYb0HLyXJZyZ5fQ+6pp4Dg3WBAFjN
+        7t3vu89kf6/eiy/r4vGrqx1Ne0d6LgzWBQJgdb+d5IlJ7t978iF2755P8hlJvrcvvKWeF4N1gQDY1O9c
+        vHHuyy5C+iOT3O0We/Tdk9wnyUOTPDrJ8/sCo/zRNGG4LhAAHKLzhMG6QABwiM4TBusCAcAhOk8YrAsE
+        AIfoPGGwLhAAHKLzhMG6QABwiM4TBrv4QAIvLy8vL6/reb2g8wQAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAltePwwOAQ3SeMFgXCAAO0XnCYF0gADhE5wmDdYEA4BCdJwzWBQKAQ3SeMFgXCAAO0XnCYF0gADhE
+        5wmDdYEA4BCdJwzWBQKAQ3SeMFgXCAAO0XnCYF0gADhE5wmDdYEA4BCdJwzWBQKAQ3SeMFgXCAAO0XnC
+        YF0gADhE5wmDdYEA4BCdJwzWBQKAQ3SeMFgXCAAO0XnCYF0gADhE5wmDdYEA4BCdJwzWBQKAQ3SeMFgX
+        CAAO0XnCYF0gADhE5wmDdYEA4BCdJwzWBQKAQ3SeMFgXCAAO0XnCYF0ghnp5khd6eXntfb2mFw3jdJ4w
+        WBeIzb0iyQOS3LZrA/xxSW5I8kDhPl7XhsG6QGzq27oewOGSPK0XFdvpejBYF4jNfFfXArh+SZ7bi4tt
+        dC0YrAvEJn49ye26FsD1S/I+Sd7ci4z1dS0YrAvEJh7XdQAuL8kze5Gxvq4Dg3WB2MTndh2Ay0vyZb3I
+        WF/XgcG6QGzi07oOwOUl+cxeZKyv68BgXSA28eldB+DyknxGLzLW13VgsC4QmxDosCCBPkbXgcG6QGxC
+        oMOCBPoYXQcG6wKxCYEOCxLoY3QdGKwLxCYEOixIoI/RdWCwLhCbEOiwIIE+RteBwbpAbOK6A92GxRmx
+        PibRdWCwLhCbsGHBftbHJLoODNYFYhM2LNjP+phE14HBukBswoYF+1kfk+g6MFgXiE3YsGA/62MSXQcG
+        6wKxiev+LPfdJtcX2eP3kjw7yVdcfL71Rya5W18P1rTruST3TvKQJF+Z5DndqO/AmuuDBXUdGKwLxCbW
+        2LB+PsnDktzQfxeOQZLbJfnCJL/czVvWWB+soOvAYF0gNrHkhvWq3Y8b+8/DMds9QvjiH6G3Zsn1wYq6
+        DgzWBWITS21Yj+g/BzO5+HF8W2p9sLKuA4N1gdjEVTesX0vyl/rPwIySPCDJmxZcH2yk68BgXSA2cZV3
+        8b46yU39/2FmST4wya8ssD7YUNeBwbpAbOKydyC/kOT2/f/gFCS5S5LfusL6YGNdBwbrArGJy9yBfGqS
+        D+//DqckyX2T/PX+79fiDn2MrgODdYHYxHXfgQD7uUMfo+vAYF0gNnHdd+jAfu7Qx+g6MFgXiE0IdFiQ
+        QB+j68BgXSA2IdBhQQJ9jK4Dg3WB2IRAhwUJ9DG6DgzWBWITm70pLskdkzw6yT/w8trw9dVJ7tz9uBaB
+        PkbXgcG6QGxi9UBP8h5Jnt4Dw8aenOTG7s+lCfQxug4M1gViE6sG+sWjK1/bg8Igr1z7bt2xtTG6DgzW
+        BWITq/0OPcmffgdPsYJRXprkT3S/LsUd+hhdBwbrArGJNQP9K3owOBJ/o/t1KQJ9jK4Dg3WB2MSagf6y
+        HgyOxI93vy5FoI/RdWCwLhCbWCXQdz/STPL7PRgciV1vrvJjd4E+RteBwbpAbGKtQL9HDwRH5gO6b5cg
+        0MfoOjBYF4hNrBXoD+qB4Mh8YvftEgT6GF0HBusCsYm1Av1LeyA4Ml/SfbsEgT5G14HBukBsYq1A/7Ye
+        CI7ME7tvlyDQx+g6MFgXiE2sFeg/0gPBkXl+9+0SBPoYXQcG6wKxibUC3QfKcOx+rvt2CQJ9jK4Dg3WB
+        2MTige7IGpNY5eiaQB+j68BgXSA2sUagO7LGLN6/+/eqBPoYXQcG6wKxiTUC/RN7EDhSn9D9e1UCfYyu
+        A4N1gdjEGoHuyBqz+Nvdv1cl0MfoOjBYF4hNrBHoT+xB4Eg9ofv3qgT6GF0HBusCsYk1At2RNWbxw92/
+        VyXQx+g6MFgXiE2sEeiv7UHgSC1+dE2gj9F1YLAuEJtYNNAdWWMyix9dE+hjdB0YrAvEJpYO9A/oAeDI
+        LXp0TaCP0XVgsC4Qm1g60B1ZYzYP7D6+CoE+RteBwbpAbGLpQP+SHgCO3Bd3H1+FQB+j68BgXSA2sXSg
+        O7LGbL61+/gqBPoYXQcG6wKxiaUD/fk9ABy5H+o+vgqBPkbXgcG6QGxi6UB3ZI3ZvKb7+CoE+hhdBwbr
+        ArGJxQLdkTUmtejRNYE+RteBwbpAbOLTug6XtTv+0xcf4GVJXug11WtXs9Hu3v18Wbt/JPfFWV/XgcGS
+        /G4XidUtGegP7Itv5CeS3Lvnw1ySfHSSn+7ibuTjej6XJdCH+D9dBwZL8sauEqtbMtC/uC++gcf2PJhb
+        km/vIm/gi3oelyXQh/jVrgODJfmprhKrWzLQH98XX9kzeg6chiTP7WKv7HE9h8sS6EP8p64DgyX57q4S
+        q1sy0H+4L76iX09yu54DpyHJHTf+Fdzzeg6XJdCH+I6uA4P5lLEhlnyX+8/1xVe0+HOsOS5JfqCLvqJX
+        9/iX5V3uQzys68BgST64q8TqlrxD39Ln9vicliRf3kVfU49/We7Qh7hb14EjkORnulKsapFAT/J+feGV
+        fVbPgdOS5HO66CtbJBQE+uZ+smvAkUjyqK4Wq1oq0Lc+sva1PQdOS5Kv76KvbJGja37kvrnP7xpwJHZv
+        dEryO10xVrNUoG99ZO2FPQdOS5L/2kVf2SJH19yhb+r1/f3nyOzuvrpqrGapQP/WvvAGPrTnwWlIcq8u
+        9ga+pedxGQJ9Uw/v7z9HJsltdv/y6sqxikXe5b7xkbW3e0mSP9VzYW5Jbkjys13sDSxydM2P3Dez+8jg
+        d+7vP0coyX27eqxiqTv01/SFN/LjSW7q+TCnJPcY+PGvr+r5XIY79E3sPqPgz/X3niOW5Gu6iixuqUAf
+        7ZlJPj7Ju/fcOG5J3ivJX0nynC7q1npul7FbU31dFueUy4ySfG9XkkVd+UfuR/KUNVjClY+u+ZH76r6h
+        v+dM4uIZ29/TFWUxSwT61kfWYC1XProm0FclzE/Bxfn03+vqcmVX/pH77rhPXxQm9cju7+vld+ir+M0l
+        9iqOSJK7J/l3XWmu5MqLZMBT1mAtVz66JtAX9/Qkd+jvMyfi4k0nr+uqcylLBPoP9UVhUs/t/r5eAn0x
+        u2OpH9HfX05Ukock+b4kb+xO4GBLBPqIM8OwhisfXRPoV/KqJP88yYP6+8oZSfJBFx8/+q93HwvqdfDr
+        Y/p7eb16RcLMur+v18VnaPQ689r/elqShya5Y38vgQ0NeMoarO2u3ecAJ8+RNU7QA7rPAU7egKeswdqu
+        fHQNYDqDnrIGa7ry0TWA6Tiyxgm68tE1gOkMfMoarOXKR9cAptM74Yb+S5LHXnxu9u6YkNfpvHafL/FN
+        Ax+jeuWjawBTufgo3q3tPs//ET0XTtPAN12+b88F4GTtnkzVu+AG7tnz4LQluU83wQbu1/MAOFkDnrLm
+        ONGZSvJ3uxlW9jd7DgAnK8njehdc0S/2+JyXJG/qpljRN/f4ACcryfN6F1zRv+jxOS9Jnt1NsaJ/0+MD
+        nKwkr+5dcEX/qMfnvFycatjKz/T4ACcrye/3Lriix/X4nJck/7ibYkVv7fEBTlKSu/UOuLIf7jlwXnY/
+        Bu+mWNldeg4AJ2fQkbXb9zw4D0lul+Qt3RAr+9ieB8DJGXBkbefreh6chyR/r5thA46uAadv4yNrt3Sv
+        ngunLclHdRNsxNE14PRtfGStfVmS2/acOC0XP2b/6i7+hhxdA05fkp/t3W9juw8ZeWKST72Vh3t4zf16
+        6O5zB5K8uYu+sVd03wOcnI2PrMEIjq4Bp23QU9ZgBEfXgNM16MgajODoGnC6Bh1ZgxEcXQNO18Aja7A1
+        R9eA0zX4yBpsydE14HQdwZE12Iqja8DpcmSNM+LoGnCaBjxlDUa7qdcBwPQcWeMMOboGnJ4kX9i7HZy4
+        R/Q6AJieI2ucoW/qdQAwvST/tnc7OHE/2OsAYHpJXtW73UZ2T9/6lCR37Tlx2i7eiPngJE/tptjIy3pO
+        ANPrnW4Db0zykT0PzlOS+yX5rW6Slf1uzwNgagOOrO2eef7+PQ/OW5IP2Z0P72ZZ2Z/peQBMK8kDepdb
+        2ef3HGAnyaO7WVZ2354DwLQ2PrL2m0neuecAO0luSPJ/u2lW9PCeA8C0kvyz3uVW9AM9PtxSkhd306zo
+        sT0+wLSSPLd3uRU9rceHW0ry3d00K/r+Hh9gWhsfWXOHzju0e7RpN82KXt7jA0xr46esvb7Hh1tK8oZu
+        mhV56hpwGpK8b+9wG/iIngfs7B6Y0s2ygTv3PACmk+T+vbtt4D/2PGAnyX/uZtnAx/Q8AKaT5G/17raR
+        b+65cN6SPKWbZCMP67kATCfJP+3dbUMvTPLxPSfOS5K/muSnujk29E96TgDTSfKc3t0G+PmLcPc6v9ev
+        dDMM4OgaML+Nj6zBMfLUNWB+Gx9Zg2Pk6Bowt90zyHtngzPl6Bowr0FH1uAYfXSvD4BpJHlk72pwphxd
+        A+a18VPW4Jg5ugbMa+OnrMExc3QNmFeSn+ldDc7U/+j1ATCN3XGd3tXgTDm6Bsxp0FPW4JjdqdcJwNFz
+        ZA3+mI/qdQJw9AY+ZQ2O1Rf0OgE4eoOfsgbH6Bt7nQAcvSN5yhocE0fXgPkkeWXvZnDmXtrrBODoObIG
+        f4yja8BcktyldzLgZnfs9QJwtJLcr3cx4Gb36fUCcLR2x3N6FwNu9nm9XgCOVpIv7V0MuNkX9XoBOFpJ
+        HtK7GHCzv9brBeBo7d7407sYcLP37PUCcNSSfFfvZHDmvr3XCcDRS3KHJG/sHQ3O1K8luX2vE4ApJPmA
+        JK/rnQ3OzC/u1kKvD4CpJLkxyT90t84ZekOSr0/yrr0uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAGC//w9pqsKgKIijOgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="MNU_Datos.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAfQAAAH0CAYAAADL1t+KAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAJNpJREFUeF7t3Qm4PmVd//FQNETBFRVFxQ2QXMISXFBBLRWX3BdckCQElUKlFFwg
+        TU3FLTeSzCxxwY3M9a9/Fwolci8NzQUxkEQwQyAlfXfdOid/fPgt55x55r5n5nm/rsvr8lI45zvPM9/5
+        nJm5l1/5FUmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmS
+        JEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmS
+        JEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmSJEmS
+        JEmSJEmSJEmSJElSArYH7gjcG3gw8GjgYOBw4CjgucDLgOOANwHvAN4PfAz4EPBu4M3A8cArgRcCzwae
+        BhwKHAA8FLgPcBfgBlmDJElaJeBmXWiXoC3h+0nge7RxMXAa8BbgOcDDgNtmzZIkLa0SjMBjgOcD7wQ+
+        n2k6ct/sngCUpwLlScGdgavkcUqSNAvArwJ7AocArwc+A/w403Emfgac3t3RlycM+5ZXBfmZSJI0esBW
+        wB7A07v313MN79UqIf+57p39PsAV8jOTJGkUgKsDj+juTM/LRNOlXAT8LfAk4Eb5WUqSVBVwXeCJwEeB
+        SzK1tGqfBZ4J7JafsSRJgwCuDxwBnJKppIUo79/LIMFb5mcvSVIv3TvxMo2sPCb+n0wgDebTwGOBbfI7
+        kSRp1YBrAUcC38qkUVVlTEKZGnfz/I4kSdqkbqrV2zJVNApl1sDD8juTJOnngO2Aw4AvZ4JolM4Cji4D
+        E/O7lCQtoTL4qlte9cJMDE3Ge4C75ncrSVoCwO7d5iVl0RPNQ1nz3mCXpGUA7Aq83SCftb8H9s7vXpI0
+        A8AuwFvzyq9ZKwPobp/ngiRpgoBrAq9xJbelVl6t7JznhiRpAoArdpuj/DCv7lpKZYOcl7rzmyRNRLeq
+        2/7AGXlFl7pFan4f2DrPHUnSSHQj1/8xr+DSRpQ14++Y55AkqSFgW+BY35NrHd5UxlnkOSVJqgx4EHBm
+        XqWlNTgfOLi8rsnzS5I0MOB6wPvyyiz1UHZ32zXPNUnSQIADgP/Mq7G0AP/d7Xd/uTzvJEkLAuwAfCCv
+        wNIATnXuuiQNAHgE8P286koDKhv2PNl365K0AMCVXLJVjX3YkfCS1ANwY+AreXWVGvgOcJs8RyVJWwDc
+        y4Fva3IB8LVup7FPrPI//+xrjDU7IM9VSdImAMfkVXTJfQ/4CPDXwIuAw4GHA3cGbl4W1snPcK2AGwJ7
+        AQ8ADgWeCxzfTQ38tyxoyb06Pz9J0gaA7ZxbzlnAe4GjgfsB18/PqYXuu9kHeCpwAvDlLHzJnFJmXeTn
+        JElLD9ipewS8TP4LOAl4DrDf1AICuDJwF+ApwJuBb+cBzty3XIhGkjYA3Bo4J6+WM1UeX78cuNscd/wq
+        A8eAZwGnAT/Lg5+hMs5j7/wcJGnpAPcGfpRXyZkpj2ePBG6Zxz9n3UJAB3WvUS7OD2VmHp3HL0lLoxt8
+        NVflUfpjgGvkcS+jbj2B3+l2N/tBflgzcXQetyTNXjeKek7K4+WPAb9bBpDl8eqXgCt04f7Obu30Ofkr
+        14GXtDS6d8hzUQaCPaPs/pbHqS3rRs8/AfhCfrAT9u48TkmalbImNvCGvPpNULkb/yBwH9f5Xhxgz26u
+        /Rzu2v+hzALIY5SkWegu1lNXni7cJI+tlm6g2R7dHPVDgOd1j3n/X7dD2Be7FeP+HTgPuGiD2suI7LOB
+        bwD/AvxTt2Lc24AXd9PPHgrcsSw0k7+7FuBa3Tz8Mq1vyj7rGvCSZgd4e17tJuZvaoZcN8e7BGsZOPg6
+        4FPd8q41XdIF/1uAp3czEqq9WgCuDhybRU1Mmaa4Ux6bJE1OGSAEvCOvchPytzUWD+mWcC3vkk8EvplF
+        jEy50y9PBMp88zvlsSxa+SMCeH33B8YUle9zxzwuSZqM7p15WUFsisrj673ymBalWxnvgG4a15n5yyem
+        PDn4AHAE8BtDjfIGdikDzvKXT0R5DeIURknTNNEBcP9aNijJY1kEYGfgqJmN6N6Y/wBe2639vvBBg90m
+        MuUPrqkp4xuumscjSaMGvCavZiNXBpAdnMfRV7eLWXn/XAZILaPvlt3Jup3hFhru3QC+sk/5lPwjcJU8
+        FkkapW7k9ZSUJwkLexwKbAP8Xnfx1i+VneSeD9wgP7P16j7rP8lfNHInl5Xz8lgkaVS698JTUbYA3TOP
+        Yb2AGwEv6e72tWn/A7wHuHt+husF3BT4ZP6iESur5C30iYUkLQzwW3nVGrE/yvrXoxv4V6ZzlQ1Ifpq/
+        RFt0OnDYopbLBR43ofnrz8/6Jak5YLeJ7JpWBqT1nobWBfmDl3AP96H8EDgG2D4/67UCrj+hu/X9s35J
+        aga4Trcy2ZiVx7zl3X7vPci7jUXmPlK9lbITW5nf3mvgWPcHV7nz33ClvDH6CXCHrF+SmgA+k1epkfne
+        IuaUd2u3j/1Y5+L73eyAbfN7WIvyNAb4av7wkTm/LCyUtUtSVd184zH7XN/lSoFbA6fkD1YV55YV9PI7
+        WYvyGB/4SP7gkSlLxPb640WS1g14UF6VRqYso7pN1r1aXRC8qntcr7bKPP7b5ne0Wt0SxC/NHzoyb8+6
+        JWlwwC2AC/OKNCJPz5rXAngMcE7+0BEpg8jKXV3ZtOUk4PhujEDZm728O/5d4BHdrmz7AvsBD+mmFT4R
+        +MNuEFpZ9KVsnPPxbhpfeT0xZscBV8vva7W6UfBjdlDWLEmDKQOWgK/nlWgkyh8Z+2XNq9W9cx3bCOmy
+        lOp7u8FiZWpg75HgmwNcAfjNLvjLWvNlalnZA34symP4x693Hjewd/feeowuBnbPmiVpECPeIKME3y2z
+        3tUCHthdUFs7A/iLMqWprP+edbZQ5okD9wJe1O2jPgYnZZ2rVfa07/aFH6Py5GUh8/IlaZOAx+bVZyQ+
+        32fwG3Df/IEVlbvFE8rjVuDGWdsYlU1GgPsDr+z2TG/l77K21er2Wx/b05gV78h6JWlhuuU1x7h4zIeA
+        K2e9q9WFU9nju6YylaosE1s2LRlku9GaumVvn9oFZO1BhH1HwZfXCmP0qKxVknorC7J0d8FjU0ayXz7r
+        XYtugFgNZfGdMmht3a8FpqC78y1Pcmrd/X49a1gr4Nn5Q0egDHy8YdYqSb10707H5tiscz0qzDEvi9E8
+        Mn/vMgD2AP4mP5AB9F6YpZsVUFZuG5Nybq5r8J8kXUY3KnhsnpZ1rteAU7XeBdwpf98y6tZXP3bAjVPu
+        kb9zPYA7Nnj9siUL2UhI0pLr9psuo67H5Iissw/g7PwFPZQd18oAt94bwMxRt1hPmX636Gljv5W/a72A
+        241sjYVLymqFWackrUm3UtqYvCBr7GuB73pLkO+WP1+X1QV7eW+9qDv2HfN39AHsA/w4f0lDX+o7VkTS
+        EiuPi/Oq0tjrs8ZFAJ6Sv2iNysA8FwNZh7LqG/Dcnrui/WP+3EXopjLWHrG/OU/JGiVpi8o0MODMvKI0
+        9KascVG6RVPWc6dYVsu7S/48rV1ZQ6DMvc4PeJUenz9vUcpgxvxlDZXXAAt9EiFpCYxsI4v/P/Tjxm6V
+        uLU4Jn+G+gPuucYxG+/Jn7FoZQBm/tKG3pX1SdImdctijuVRY9n+dN2LxqzFKnePK39c9J4ipc3rBs5t
+        yWvy3xsK8Of5yxu6d9YnSRsFfDSvII2UO7Udsr4hATt173S/E7V8BXhA/vMaDnAD4A3xPRTlj6p98p8f
+        GvDOLKSR8ips3dsCS1oSJbTy6tFImdZ0s6xPy6nbrnevlpuWdFM4T80TtZFnZn2S9H+AXx3JQLiyVedC
+        FgqRFgm4DnBOnrANlAFyVZ9eSZoQ4Mi8ajTy7KxNGosRrZx4fNYmSeUi1WLHsY35iGtXa+wqbuizOeVJ
+        lusfSLo04Hl5tWjg2+UPi6xNGiPgvXkCN/CJrEvSEgOuNZK1q/fK2qSx6pavPStP4gb2y9okLaluF6zW
+        /jTrksYOuFueyA18NuuStISA6wIX5xWisi9nXdJUlD0G8oRuYGG7zUmaKOAVeWWozK0hNWndvgdrWa52
+        CKdkXZKWCHDtEdydH511SVMD3D1P7AbumnVJWhLAS/KKUNnpwNZZlzRFZUfAPMEr+2jWJGkJdCPbW9+d
+        7511SVNVVm4bwVoOe2ZdkmYOeGFeCSr7y6xJmrqyN3ue6JW9LWuSNGPAtsB/5ZWgou8DV8u6pDkoA9Ty
+        hK/op2XHwKxJ0kwBh+RVoLLfy5qkuSjLsXbLsrbimg7Ssuj29m7ly67VrrkrG6fkiV9Refq2bdYkaWaA
+        fbP7K7tL1iTNTTdAruVyyodkTZJmBnhXdn5F78l6pLlqvB3xV7MeSTMCXC+7vrKbZk3SnAH/nk1Q0Z2y
+        Hkkz0XgP57/KeqS5A56cjVCRU0OluQK+mB1fSZlKc7OsR5o74IrAudkQlfyorDOfNUmauG4qTSsnZD3S
+        sgCelg1R0eOzHkkTB7woO72SMh/Xu3MtLeBKwA+yMSr5VNYjaeKA72SnV/LurEVaNsCzsjEq2iXrkTRR
+        wJ2zwyty3rmWXrcZUitHZT2SJgp4WXZ4JZ/PWqRlVUadZ4NU8pmsRdJEAd/ODq/ksVmLtKwaD0zdMeuR
+        NDHAr2dnV3IOsHXWIy0z4BPZKJUcnrVImhjgmOzsSl6QtUjLDtg/G6WSk7MWSRNT3mNnZ1eya9YiLTtg
+        G+CCbJZKdsh6JE1Ew7XbT8taJP0C8MZsmEr2z1okTQTwhOzoSp6UtUj6hYZbGL8ha5E0EWW70uzoCn4C
+        XC1rkfQLwFaNFnr6VtYiaQKAywMXZkdX8HdZi6RLA16cjVPJTbIWSSPX8LHeY7IWSZcG3C4bp5KDshZJ
+        I1emjWUnV7J91iLpsoAzs3kqeEvWIWnkGi1gcVLWIWnjGj12PzvrkDRywEXZyRU4LUZaJWDPbKBKbpi1
+        SBop4DbZwZVcNWuRtHHdaPcW+6Q/PGuRNFKN5p9/NuuQtHnAidlIFbw865A0Uo22afzTrEPS5gEHZyNV
+        cGrWIWmkgH/JDq7g7lmHpM0DbpyNVEPWIWmksnkruChrkLQ6ZQW3bKgK9sw6JI0M8BvZuRX8fdYhaXWA
+        v8mGquDxWYekkQEOzM6t4MVZh6TVKZsZZUNV8NKsQ9LIAK/Izq3ggVmHpNVp9FTtQ1mHpJEBPp6dW8E1
+        sw5JqwNcrsFCUGdmHZJGBvhedu7AzsgaJK0NcHI2VgXbZR2SRqJsjJIdW8F7sw5JawO8Nhurgr2yDkkj
+        AeyRHVuBC8pIPQGHZWNV8KisQ9JIAA/Njq3gsVmHpLUpCzNlY1VwVNYhaSSAZ2THVvCbWYektQGul41V
+        wXFZh6SRAP4iO7aCK2YdktYOuCCba2AfyBokjQTw4ezYgZ2dNUhan7JjYTbYwP4la5A0EsDns2MH9qms
+        QdL6AO/OBhvYhVmDpJEod8zZsQN7S9YgaX2Al2WDVbB91iGpMWAr4GfZrQN7QdYhaX2AP8gGq+CmWYek
+        xsryq9mpFRycdUhaH+AB2WAV3C7rkNQYsHt2agX3zTokrU9ZuS0brIJ7ZR2SGgP2zk6t4A5Zh6T1AW6e
+        DVbB/lmHpMbKX9rZqRXsknVIWp9Gr80OyzokNQY8JDu1gqtnHZLWLxusgqOzBkmNAQdmpw6sjKjfKuuQ
+        tH7A+dloA3NzJWlsgN/PTh3YBVmDpH6AM7PRBvayrEFSY8CR2akDOzdrkNQP8G/ZaAP7s6xBUmPAc7JT
+        B+Y67tKCAf+ajTawP88aJDVWBrdkpw7sjKxBUj/Al7LRBvbGrEFSYw0C/WtZg6R+Guy49uasQVJjwDHZ
+        qQP7StYgqR/gtGy0gZ2QNUhqDPjj7NSBfSNrkNQP8MVstIG9KWuQ1FiDO/QzswZJ/ZQnX9loA3t91iCp
+        MeCo7NSBnZM1SOqnPPnKRhvYq7MGSY0Bh2enDuy8rEFSP8C/Z6MNzIVlpLEBDspOHdhFWYOkfsofytlo
+        A3th1iCpMeDR2alDyxok9ZM9VsEfZw2SGgMelJ1awY5Zh6T1Aa6RDVbBU7MOSY0B98xOrWD3rEPS+gA3
+        zQar4ICsQ1JjwO2yUyvYO+uQtD7AntlgFdwv65DUGHCj7NQK7p91SFofYL9ssArulHVIagy4YnZqBYdl
+        HZLWBzg0G6yCW2QdkkYAuDC7dWDHZg2S1gd4UTZYBdfOOiSNAPDN7NaBvT1rkLQ+wNuywYaWNUgaCeDT
+        2bADOy1rkLQ+wKnZYAP7dtYgaSQa/IV/btYgaX2A72WDDezkrEHSSDR6B3fNrEPS2jRaVObNWYekkWg0
+        SnafrEPS2gD7ZmNV8PysQ9JIAPfOjq3gSVmHpLUpU0CzsSp4QtYhaSSA3bJjK3hN1iFpbYDjsrEq+O2s
+        Q9JIANtkx1bgwBqpJ+BT2VgV3CjrkDQiwDeyawd2EXC5rEPS6pT+AX6SjTWwH2UdkkYGOCk7t4JbZh2S
+        VgfYIxuqAteQkMYO+JPs3AoOzDokrU4ZnJYNVcEbsw5JIwM8PDu3gtdlHZJWB3hDNlQFR2QdkkYG2D07
+        t4LPZB2SVgf4UjZUBffKOiSNEHBxdm8F22cdkjYP2CEbqZLrZC2SRgj4h+zeCh6QdUjaPOCR2UgVuCmL
+        NBVln/Ls4ApenXVI2jzgL7ORKnhb1iFppICHZgdXcHrWIWnzGuywVvxB1iFppICdsoMr2SlrkbRxwC7Z
+        QJXsmbVIGjHgP7KLKzgs65C0ccCR2UAVXAJsnbVIGjHgrdnJFbiuu7RKwOeygSqwR6WpAQ7KTq7gZ8B1
+        sxZJlwbcLJunkudkLZJGDtg5O7mSJ2ctki4NeGY2TiV3yFokTUCDndcKH+lJWwB8ORungh9mHZImAnh9
+        dnQljnaXNgG4TTZMJe/KWiRNBPCw7OhKnpW1SPqFRgs/FQdnLZImAtguO7qSr2Utkn6h0WIyxY2zFkkT
+        Anw0u7qS22ct0rID9stGqeRLWYukiSmLvWRnV+Ie6VIATsxGqeTorEXSxADXy86u5EK3VJV+qVuS+afZ
+        KJXcKuuRNEHAF7K7Kzkia5GWFfCibJBK3C5VmovyuC07vBIvJNIvenBb4PxskEpemPVImijgJtnhFT0o
+        65GWDXBoNkZF7q4mzQlwSnZ5JZ/OWqRlU6ZyZmNU8vWsRdLEAYdkp1e0b9YjLQtg/2yIip6d9UiaOODq
+        wE+y2yv5WNYjLQNgK+DfsiEqKbsfXi9rkjQDwDuz4yu6Y9YjzR3wkGyEivxDWpor4D7Z8RV9MOuR5qy7
+        O2+xq9qKA7ImSTMBXA44O7u+IpeD1dJo/O78YmCbrEnSjDSck158LuuR5gr4TjZARcdnPZJmBtix4fKT
+        xeOyJmluyujyPPEr2zVrkjRDwPuz+ysqW0dumzVJc9H90Vz2MmjlI1mTpJkC7pdXgMqemzVJcwH8dZ7w
+        le2XNUmaqW707VfzKlBRmQ/vI0HNDrBPnuyVfbP0d9YlacaAx+aVoLJTsiZpyoBf7QK1pUOzLklLAPhW
+        Xg0qe0zWJE0VcEye4JWdC1wp65K0BIAn5BWhsnIBulrWJU1NeYUEXJIneGXPyLokLQngisBZeVWo7MSs
+        S5oSYGvg83liV/YD4CpZm6QlAhyWV4YGDsy6pKkAnp8ndAPuqiYtu+4uveVysMWPgJtkbdLYAXt3u5q1
+        dIF355J+DnhiXiEa+Gx5dJm1SWNVxn8A380TuQHXdZD0S43XnV7x4qxLGivgfXkCN1Duzq+etUlaYiMY
+        8b7iflmbNDbAkXniNvIHWZsklYtU60UxivI+/aZZmzQWwF3zpG3ka1mbJP0c8MC8YjTylbLqVtYntQZc
+        DzgvT9hG7p/1SdL/AT6WV41G3pq1Sa0Bp+aJ2sjHszZJuhRgd+B/8urRyB9lfVIrwAl5gjZSpsntnvVJ
+        0mUAr8orSCPlwnXPrE+qrSyrmidnQ6/J+iRpo7r5tefnVaSRMkjuFlmjVAvwO3lSNlTmvW+XNUrSJgGP
+        yytJQ2cAO2SN0tCAW3d/VI7Fw7NGSdoi4FN5NWnoXw111dSNaD8nT8SGHAgnaX26LSH/O68qDRnqqqI8
+        1gZOzxOwodKHN846JWnVyi5OeWVprIT6tbNOaZHK3XCeeI0dlTVK0pqN7E6lMNQ1mLIGQp5wjZ2aNUrS
+        ugC3AX6SV5nGyjK1N8xapfUqu/0BJ+aJ1lgZkOejdkmLAxyaV5oROMuLnRahLDUMfCBPsBE4KGuVpN6A
+        t+fVZgT+w1Wz1AdwZeDkPLFG4H1ZqyQtBLDtCN+nF/8J3CHrlbYEuCbwT3lCjUBZQMZ9ziUNp6zaBlyU
+        V5+ReGTWK20K8GvdokVjdPesV5IWCthnZHPT09FZs5S6Pc0vyJNnJJ6b9UrSQk0gzFeUaUdXzPqlAjhw
+        RDsKpjL//XJZsyQtzITCfMXnnNamDXUj2f8iT5QRKcvMXjPrlqSFmWCYryiD5e6Rx6PlU6Y3Al/KE2RE
+        furATkmDAu4GXJxXn4l5fh6XlgfwQOCHeVKMzNOzbklamDLSdgZhvuITwHXyGDVvwJ/liTBCJ2TdkrQw
+        E37MvjnnAvvmsWp+gJ2BL+QJMEJli+IrZP2StBAzDfMVPwNeAFw+j1vzADxsxFPSNvQtF4+RNJjuMfsy
+        OAW4aR6/pgvYHjg+v+iR+gFw8zwGSVqImd+Zb0w51j8u05nys9C0AI/t1vWfgrJzoSPaJQ1jCcN8Q+XR
+        593yM9H4Abt2T1umorzyeXAehyQtxMxGs/fxLh/DT0N59wy8PL/ACXhiHoskLcSS35lvzCXAa4Ed8rNS
+        e8A2wDO6RYOm5gV5PJK0EDNZNGYoFwLHANvl56Y2gIOAs/KLmog35PFI0kJ4Z75qZTTyc4Fr5Geo4XXr
+        rz+xG+cwVR92mqSkQRjm6/Ij4FhXm6sDuDLwh8B384uYmA84i0LSIAzz3spnd1zZ7CM/W/VXnoR0T0TO
+        zw9+gk4Ets5jlKTeDPOFKvtpvwW4VX7OWjtgJ+CV3diFOXgDsFUepyT1VrYRdQDcYD4KHABcKT93bR5w
+        X+Ct+YFO3EvyOCVpIRzNXk25u3wz8Nv5HeiXgL2A183ksXp6Th6vJC2Ej9mb+R7wxm4v7m3ze1kmZTcx
+        4LeAVwFn5Ac1E2U510fksUvSQnSP2TUOZbTzocsySr5bye3AbmDYf+WHMTM/LH8452cgSQvhnflolbW8
+        PwMcDdw2v7cpA3brppqd3A0aXAbfBnbJz0KSFsIwn5TzgI8ALwQeMpXpcN2o9Pt3u9W9bwbzxdej/GF2
+        rfxsJGkhHM0+C+URbhk5/6LyXrb1vtnAzmWHMOB5wIeAc7PgJVSmLDqrQdIwul3TNF9lQNmngXcDr+ke
+        2z8V+D3gkd0UsLsAv9FtK3p9YPvu3LgKcN3yx0F51N/9c/fp/mAoa6Q/BXh2N3Dtnd2WpN/0j8ONemr2
+        niQtTBlJvQSDj6SWypOJvbP3JGnhZjzffI7zlTUtpwE7Zs9J0mBm+Nj9UcC1gb/L/0Oq5BXZZ5JUxUxG
+        uZfpXZdaqAN4XDdgTKrhTOBOG56DklTdxEP9MmG+ArgR8Mn8F6QFO75s4ZrnnyQ1MdFQ32SYryi7WAFP
+        Bi7Kf1nq6awy9TPPOUnaom6a0JPzf18UYN+8Yo3c/nkMmwLcDDg1f4C0Tn8OXC3PM0naoi7MVzwr//9F
+        mcid+hbvzDcGuDxwJPDj/IHSKn0Z2DPPLUlalQjzFcfkP7coXaiP9RH1usJ8Q92CKWV1NWm1LugW1Ll8
+        nk+StCqbCPMVQ4b63t2e3WPz6Kx1vbrVz76Wv0AK7ykr6eX5I0mrtoUwXzFkqN9xRHfqve/MNwbYGjgc
+        +EH+Qi29zwN75TkjSWuyyjBfMfdQHyTMN1R2wgKOA36av1xLp8wpf3SZIZHniSStyRrDfMVcQ33wMN8Q
+        8GvAP2QRWgplf4NnAtvkeSFJa7bOMF8xZKiXHbdarP3+qKylBuBhwFeyGM1S+WP1xe5XLmlheob5iiFD
+        veadetU7800B7umI+Nkq5/KxBrmkhVpQmK+YeqiPIsw3BNwKeAtwSRarySlPml5eNvLJ71mSellwmK+Y
+        aqiPLsw3BOxUdtTq5iVrWr4FPN07ckmDGCjMVwwd6osOtVGH+YaAqwJHAd/Ng9ColFkL7+/WHHDUuqRh
+        DBzmK4YO9R/lL+xh1WuzjwnwcOBv82DU1PnAC8uOe/l9SdJCVQrzFUOG+u0WcKc+mTvzzQGuAfw+8Nk8
+        QFVTtst9JHCF/H4kaeEqh/mKsYb6LMI8AbsALwHOzgPWwpVV/v6s7KiX34MkDaZRmK8YMtT3WmeoN5ln
+        XhNwb+CdC349sexKiP81cP/8vCVpcI3DfMWQob6WO/VZ3plvTnkM3O05X+Y+u2jN2pWnHa8F7uGuZ5Ka
+        GUmYr2gd6ksX5htTBmwBT+pGYQ81DXDKyprqJwCHlCV58/OTpOpGFuYrhgz123frYm/K7B+zrxVwpW5q
+        1auBf84PbEmU4y534I8Bds7PSJKaGmmYrxgy1Dd2p+6d+SqVDUK6z/Bg4HXAqTO7i/8x8KluDfX7A1fP
+        z0CSRmPkYb5iyFDfM+7UvTPvqdsNrmzt+VLgI8A3Nvh8x+hC4NPdALayEE8J793zuCRptCYS5iuGDPXf
+        BP7TMB8WsGM306DsEndEN43rJOA04Lz8whfk+8DpwMnA27qFXA7rXh3s4RKrkiZvYmG+YshQv2r+b6qv
+        PNYGbgDs1v2hdVfgvuU1CHAQcDjwrO5Ouvz38ri/PA14EHAv4E7ArsA182dL0uxMNMxXDBbqkiRNxsTD
+        fMXz8rgkSVoaMwnzFa/K45MkafZmFuYrDHVJ0vKYaZivMNQlSfM38zBfYahLkuZrScJ8haEuSZqfJQvz
+        FYa6JGk+ljTMVxjqkqTpW/IwX2GoS5KmyzC/FENdkjQ9hvlGGeqSpOkwzDfLUJckjZ9hviqGuiRpvAzz
+        NTHUJUnjY5ivi6EuSRoPw7wXQ12S1J5h3puBLklqyzDvzTCXJLVlmPdmmEuS2jLMezPMJUltGea9GeaS
+        pLYM894Mc0lSW4Z5b4a5JKktw7w3w1yS1JZh3pthLklqyzDvzTCXJLVlmPdmmEuS2jLMezPMJUltGea9
+        GeaSpLYM894Mc0lSW4Z5b4a5JKktw7w3w1yS1JZh3pthLklqyzDvzTCXJLVlmPdmmEuS2jLMezPMJUlt
+        Gea9GeaSpLYM894Mc0lSW4Z5b4a5JKktw7w3w1yS1JZh3pthLklqyzDvzTCXJLVlmPdmmEuS2jLMezPM
+        JUltGea9GeaSpLYM894Mc0lSW4Z5b4a5JKktw7w3w1yS1JZh3pthLklqyzDvzTCXJLVlmPdmmEuS2jLM
+        ezPMJUltGea9GeaSpLYM894Mc0lSW4Z5b4a5JKktw7w3w1yS1JZh3pthLklqyzDvzTCXJLVlmPdmmEuS
+        2jLMezPMJUltGea9GeaSpLYM894Mc0lSW4Z5b4a5JKktw7w3w1yS1JZh3pthLklqCzgg00lrYphLktoC
+        7gH8JBNKq2aYS5LaAq4DnJMJpVUzzCVJbQGXAz6WCaVVM8wlSe0Bh2RCadUMc0lSe8D1gQsypbQqhrkk
+        aRyA4zKltCqGuSRpHIBtgQszqbRFhrkkaTx8d74uhrkkaVyAL2RaabMMc0nSuAC/nmmlzTLMJUnjA7wi
+        E0ubZJhLksYJ+ESmljbKMJckjVO3MtzFmVy6DMNckjRewG6ZXLoMw1ySNG7AAzK9dCmGuSRp/IBnZILp
+        /7wyPy9JkkYJ+NNMMf2cd+aSpOlw/faNMswlSdMC/FWm2ZIzzCVJ0+Mj90sxzCVJ0wQck6m2pAxzSdJ0
+        ucvazxnmkqRpA/bJdFsyhrkkafqAnTPhlohhLkmaD+CMTLolYJhLkuZlCaeuGeaSpPkBHpeJN2OGuSRp
+        noDtgB9n8s2QYS5JmjfgpEy/mTHMJUnzB9wrE3BGDHNJ0nIAtgJOzyScAcNckrRcZjg4zjCXJC0n4OOZ
+        ihNlmEuSlhewK3BBpuPEGOaSJAGHZ0JOiGEuSVIBXB74+0zKCTDMJUnaEHCziT16N8wlSdoY4MbA2Zmc
+        I2SYS5K0OcAtRh7qhrkkSasB3BD4WibpCByRtUqSpM0AdgA+kYnayEXAgVmjJElahW70+58AP8uErag8
+        KbhV1iZJktYI2AN4fybtwM4FngZcKeuRJEk9ALcHPpjJu2DnlXflwFXy90uSpAXqgv3ETOKevg48Hbhy
+        /j5JkjQg4BrAk4G3A1/NhN6CHwInA8cCd86fLUmSGinvu4E7AIcCx2zkP88EHgjcJP9dSZIkSZIkSZIk
+        SZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIk
+        SZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIk
+        SZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkTcf/AmRSW/i2jRhjAAAAAElFTkSuQmCC
+</value>
+  </data>
   <data name="BTN_RegresarReporteProducto.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAfQAAAH0CAYAAADL1t+KAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
@@ -833,7 +1120,7 @@
   <data name="BTN_CCLimpiarCierre.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAfQAAAH0CAYAAADL1t+KAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vQAADr0BR/uQrQAALu9JREFUeF7t3Xv8feWY//GphNJJlIQcMsmhkXLIYSqXuPBtSMNQTjUOUzkUoYgo
+        vAAADrwBlbxySQAALu9JREFUeF7t3Xv8feWY//GphNJJlIQcMsmhkXLIYSqXuPBtSMNQTjUOUzkUoYgo
         p5AKTb/kbEQoaSRGDh2oEXIW6eqoUilKitD8HreWh7pc3+93r7XXWvd9r/16Ph7vf3r0vfe11t77uj97
         77Xu+x/+AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
@@ -1305,6 +1592,12 @@
         QmCC
 </value>
   </data>
+  <metadata name="PrintDocument.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>165, 18</value>
+  </metadata>
+  <metadata name="PrintDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>300, 18</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAAAAAAAEAIACNigAAFgAAAIlQTkcNChoKAAAADUlIRFIAAAEAAAABAAgGAAAAXHKoZgAAAAFv

--- a/SistemaFacturación/P_ReporteVentas.vb
+++ b/SistemaFacturación/P_ReporteVentas.vb
@@ -1,5 +1,6 @@
 ﻿Imports System.Configuration
 Imports System.Data.SQLite
+Imports System.Drawing.Printing
 Imports System.Globalization
 Imports System.Windows.Forms
 Imports Guna.UI2.WinForms
@@ -140,6 +141,11 @@ Public Class P_ReporteVentas
 
 #Region "Reporte de ventas"
 
+    Friend encabezadoFactura As String
+    Friend encabezadoProds As String
+    Friend facturaContenido As New List(Of String)()
+    Friend finFactura As String
+
     Private Sub BTN_GenReporte_Click(sender As Object, e As EventArgs) Handles BTN_GenReporte.Click
         MostrarReporteVentas()
     End Sub
@@ -165,6 +171,7 @@ Public Class P_ReporteVentas
             }
             DGV_FactReporte.AutoGenerateColumns = True
             DGV_FactReporte.DataSource = bin
+            DGV_FactReporte.Columns(0).Visible = False
 
             'Se agrega el total de ventas global
             TXT_TotalVentas.Text = reporte.total_ventas.ToString("C", New CultureInfo("es-CR"))
@@ -198,6 +205,115 @@ Public Class P_ReporteVentas
 
     Private Sub BTN_RegresarReporte_Click(sender As Object, e As EventArgs) Handles BTN_RegresarReporte.Click
         Regresar()
+    End Sub
+
+    Private Sub MNU_REIMPRIMIR_Click(sender As Object, e As EventArgs) Handles MNU_REIMPRIMIR.Click
+        encabezadoFactura = ""
+        'Se limpia la lista de productos
+        For Each line As String In facturaContenido.ToList()
+            facturaContenido.Remove(line)
+        Next
+
+        finFactura = ""
+        GENERAR_FACTURA(DGV_FactReporte.SelectedRows(0).Cells(0).Value.ToString(), True)
+        ImprimirFactura()
+    End Sub
+
+    Private Sub MNU_Datos_Click(sender As Object, e As EventArgs) Handles MNU_Datos.Click
+        Dim datosFactura As New Cls_DatosFactura With {
+            .IdFactura = DGV_FactReporte.SelectedRows(0).Cells(0).Value.ToString(),
+            .NumFactura = DGV_FactReporte.SelectedRows(0).Cells(1).Value.ToString(),
+            .Fecha = DGV_FactReporte.SelectedRows(0).Cells(2).Value.ToString(),
+            .Cliente = DGV_FactReporte.SelectedRows(0).Cells(3).Value.ToString(),
+            .Cajero = DGV_FactReporte.SelectedRows(0).Cells(4).Value.ToString(),
+            .Comentario = DGV_FactReporte.SelectedRows(0).Cells(5).Value.ToString(),
+            .Efectivo = DGV_FactReporte.SelectedRows(0).Cells(6).Value.ToString(),
+            .Tarjeta = DGV_FactReporte.SelectedRows(0).Cells(7).Value.ToString(),
+            .TotalCaja = DGV_FactReporte.SelectedRows(0).Cells(8).Value.ToString(),
+            .TipoPago = DGV_FactReporte.SelectedRows(0).Cells(9).Value.ToString(),
+            .Vuelto = DGV_FactReporte.SelectedRows(0).Cells(10).Value.ToString()
+        }
+        ' Crea la instancia del formulario
+        Dim frmDatosFactura As New P_DatosFactura With {
+            .Owner = Me
+        }
+
+        ' Llama a la nueva subrutina para cargar los datos en el formulario
+        frmDatosFactura.CargarDatos(datosFactura)
+
+        ' Muestra el formulario
+        frmDatosFactura.Show()
+    End Sub
+
+    Private Sub BTN_GenerarReporteVentaPDF_Click(sender As Object, e As EventArgs) Handles BTN_GenerarReporteVentaPDF.Click
+
+    End Sub
+
+    Private Sub PrintDocument_PrintPage(sender As Object, e As Printing.PrintPageEventArgs) Handles PrintDocument.PrintPage
+        Dim font As New Font("Arial", 12)
+        Dim fontProds As New Font("Segoe UI", 9)
+        Dim brush As New SolidBrush(Color.Black)
+        Dim stringFormat As New StringFormat() With {
+        .Alignment = StringAlignment.Near,
+        .LineAlignment = StringAlignment.Near
+        }
+
+        Dim totalWidth As Single = 72 * 3.78
+        Dim cellWidth As Single = totalWidth / 4
+        Dim leftMargin As Single = e.MarginBounds.Left
+        Dim topMargin As Single = e.MarginBounds.Top
+        Dim yPos As Single = topMargin
+
+        ' Dibujar el encabezado
+        e.Graphics.DrawString(encabezadoFactura, font, brush, leftMargin, yPos, stringFormat)
+        yPos += e.Graphics.MeasureString(encabezadoFactura, font).Height + 10 ' Espacio adicional después del encabezado
+
+        ' Dibujar el encabezado de la tabla de productos
+        e.Graphics.DrawString(encabezadoProds, fontProds, brush, leftMargin, yPos, stringFormat)
+        yPos += e.Graphics.MeasureString(encabezadoProds, fontProds).Height + 10 ' Espacio adicional después del encabezado
+
+        ' Dibujar los productos
+        For Each line As String In facturaContenido
+            Dim columns() As String = line.Split(New Char() {"."c}, StringSplitOptions.RemoveEmptyEntries) ' Cambiar el delimitador si es necesario
+
+            Dim maxHeight As Single = 0
+
+            For colIndex As Integer = 0 To columns.Length - 1
+                Dim rect As New RectangleF(leftMargin + (colIndex * cellWidth), yPos, cellWidth, 0)
+                Dim size As SizeF = e.Graphics.MeasureString(columns(colIndex), fontProds, rect.Size, stringFormat)
+
+                If size.Height > maxHeight Then
+                    maxHeight = size.Height
+                End If
+
+                rect.Height = maxHeight
+                e.Graphics.DrawString(columns(colIndex), fontProds, brush, rect, stringFormat)
+            Next
+
+            yPos += maxHeight + 5 ' Asegurar que el yPos se incremente para cada línea de productos
+        Next
+
+        yPos += 10 ' Espacio adicional después de los productos
+        e.Graphics.DrawString(finFactura, font, brush, leftMargin, yPos, stringFormat)
+    End Sub
+
+
+    ' Método para iniciar la impresión
+    Private Sub ImprimirFactura()
+        Dim printDoc As New PrintDocument()
+        AddHandler printDoc.PrintPage, AddressOf PrintDocument_PrintPage
+        ' Configurar el tamaño de papel personalizado en pulgadas
+        Dim customPaperSize As New PaperSize("Custom", CInt(72 * 3.937), CInt(297 * 3.937))
+        printDoc.DefaultPageSettings.PaperSize = customPaperSize
+
+        ' Configurar márgenes a cero
+        printDoc.DefaultPageSettings.Margins = New Margins(0, 0, 0, 0)
+
+        Dim printPreview As New PrintPreviewDialog With {
+            .Document = printDoc
+        }
+        printDoc.Print()
+
     End Sub
 #End Region
 

--- a/SistemaFacturación/SistemaFacturación.vbproj
+++ b/SistemaFacturación/SistemaFacturación.vbproj
@@ -255,6 +255,7 @@
     <Compile Include="ApplicationEvents.vb" />
     <Compile Include="Cls_AtrFactura.vb" />
     <Compile Include="Cls_CierreCaja.vb" />
+    <Compile Include="Cls_DatosFactura.vb" />
     <Compile Include="Cls_ProductoCaja.vb" />
     <Compile Include="Cls_ProductosMasVendidos.vb" />
     <Compile Include="Cls_ReporteVentas.vb" />


### PR DESCRIPTION
# Nuevo
## Reporte de ventas
- Ahora se puede ver os datos de las facturas directamente desde el reporte sin tener que irse a la pestaña de reimprimir facturas como se hacía antes
- Ahora también desde aquí se puede reimprimir la factura

# Bug fix
- Se arregló un error donde si el usuario agregaba un producto y le cambia la cantidad pero no presionaba enter antes de agregar otro producto, el total de este no se actualizaría, pero ahora en el momento en el que se deje de tener en focus este se actualizará automáticamente, pero se recomiendo siempre usar el enter para aegurarse de que no haya fallos
- Se modificó el como se maneja el objeto de las facturas mejorando lo que se muestra en el reporte de ventas, viendo ahora, el comentario, el cajero que hizo la factura y el vuelto que se le entrego al cliente
- A la hora de agregar un producto que ya existía en la lista de la factura que se estab haciendo antes aparecía 2 veces en esta, pero ahora simplemente se aumentará la cantidad de este por el indicado directamente sin tener que hacerlo manualmente