### PR TITLE
Creación de PDFs de los reportes de ventas y fix de la impresión de las facturas

### DIFF
--- a/SistemaFacturación/App.config
+++ b/SistemaFacturación/App.config
@@ -60,11 +60,39 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Syncfusion.Compression.Base" publicKeyToken="3d67ed1f87d44c89" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-31.1462.19.0" newVersion="31.1462.19.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Syncfusion.Licensing" publicKeyToken="632609b4d040f6b4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-31.1462.18.0" newVersion="31.1462.18.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.9" newVersion="9.0.0.9" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.9" newVersion="9.0.0.9" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.9" newVersion="9.0.0.9" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/SistemaFacturación/Cls_DatosFactura.vb
+++ b/SistemaFacturación/Cls_DatosFactura.vb
@@ -9,5 +9,5 @@
     Public Property Vuelto As String
     Public Property TipoPago As String
     Public Property Comentario As String
-    Public Property TotalCaja As String
+    Public Property TotalCaja As Decimal
 End Class

--- a/SistemaFacturación/Cls_Sucursal.vb
+++ b/SistemaFacturación/Cls_Sucursal.vb
@@ -4,4 +4,5 @@
     Public Property Telefono As String
     Public Property Email As String
     Public Property Cedula As String
+    Public Property logo As String
 End Class

--- a/SistemaFacturación/Md_CONEXION.vb
+++ b/SistemaFacturación/Md_CONEXION.vb
@@ -62,6 +62,7 @@ Module Md_CONEXION
 #Region "Interaccion"
     ' Carga datos en un DataSet usando parámetros en la consulta SQL
     Public Sub CargarTablaParam(ByVal t As DataSet, ByVal consulta As String, ByVal parametros As List(Of SQLiteParameter))
+        t.Tables.Clear()
         Using db As New SQLiteConnection(GetConnectionString())
             Try
                 db.Open()
@@ -86,6 +87,7 @@ Module Md_CONEXION
 
     ' Carga datos en un DataSet usando una consulta SQL simple
     Public Sub Cargar_Tabla(ByVal t As DataSet, ByVal consulta As String)
+        t.Tables.Clear()
         Using db As New SQLiteConnection(GetConnectionString())
             Try
                 db.Open()

--- a/SistemaFacturación/Md_IMPRIMIR.vb
+++ b/SistemaFacturación/Md_IMPRIMIR.vb
@@ -13,10 +13,17 @@ Module Md_IMPRIMIR
     Friend facturaContenido As New List(Of String)()
     Friend finFactura As String
 
+    Private Sub LIMPIAR()
+        encabezadoFactura = ""
+        facturaContenido.Clear()
+        finFactura = ""
+    End Sub
+
     ' Genera el contenido de la factura para impresión o reimpresión
     ' id_factura: ID de la factura a imprimir
     ' reimprimir: True si es reimpresión, False si es impresión normal
     Public Sub GENERAR_FACTURA(id_factura As Integer)
+        LIMPIAR()
         Dim factura As New Cls_DatosFactura()
         factura = ObtenerDatosGeneralesFactura(id_factura)
 
@@ -89,16 +96,27 @@ Module Md_IMPRIMIR
     Private Function ObtenerComentario(id_factura As Integer) As String
         ' Obtener comentario asociado a la factura
         T.Tables.Clear()
-        SQL = "SELECT comentario FROM factura WHERE ID = " & id_factura
+        SQL = "SELECT comentario FROM factura_comentario WHERE ID_Factura = " & id_factura
         Cargar_Tabla(T, SQL)
-        'Se retorna el comntario o una cadena vacía si no existe
-        Return If(IsDBNull(T.Tables(0).Rows(0).Item(0)), "", T.Tables(0).Rows(0).Item(0))
+
+        Dim comentario As String = "" ' Inicializamos la variable del comentario
+
+        ' Verificamos que se haya cargado al menos una tabla
+        If T.Tables.Count > 0 Then
+            ' Luego verificamos que esa tabla tenga al menos una fila
+            If T.Tables(0).Rows.Count > 0 Then
+                ' Si hay una fila, obtenemos el comentario
+                comentario = If(IsDBNull(T.Tables(0).Rows(0).Item(0)), "", T.Tables(0).Rows(0).Item(0))
+            End If
+        End If
+
+        Return comentario
     End Function
 
     Private Function ObtenerDatosSucursal() As Cls_Sucursal
         ' Obtener datos de la sucursal desde la base de datos
         T.Tables.Clear()
-        SQL = "SELECT nombre, direccion, telefono, email, cedula FROM sucursal WHERE ID = 1"
+        SQL = "SELECT nombre, direccion, telefono, email, ced_juridica  FROM sucursal WHERE ID = 1"
         Cargar_Tabla(T, SQL)
         Dim sucursal As New Cls_Sucursal With {
             .Nombre = If(IsDBNull(T.Tables(0).Rows(0).Item(0)), " ", T.Tables(0).Rows(0).Item(0)),

--- a/SistemaFacturación/Md_PROCESOS_BD.vb
+++ b/SistemaFacturación/Md_PROCESOS_BD.vb
@@ -160,8 +160,8 @@ Module Md_PROCESOS_BD
                 T.Clear()
                 SQL = "SELECT MAX(" & PK & ") FROM " & TABLA
                 Cargar_Tabla(T, SQL)
-                If T.Tables(0).Rows.Count > 0 AndAlso Not IsDBNull(T.Tables(0).Rows(0).Item(1)) Then
-                    OBTENERPK = T.Tables(0).Rows(0).Item(1) + 1
+                If T.Tables(0).Rows.Count > 0 AndAlso Not IsDBNull(T.Tables(0).Rows(0).Item(0)) Then
+                    OBTENERPK = T.Tables(0).Rows(0).Item(0) + 1
                 Else
                     OBTENERPK = 1
                 End If

--- a/SistemaFacturación/Md_Reportes.vb
+++ b/SistemaFacturación/Md_Reportes.vb
@@ -1,9 +1,21 @@
 ﻿Imports System.Configuration
 Imports System.Data.SQLite
+Imports System.Globalization
+Imports System.IO
+Imports Microsoft.VisualBasic.Logging
 Imports Syncfusion.Pdf
 Imports Syncfusion.Pdf.Graphics
+Imports Syncfusion.Pdf.Grid
 
 Module Md_Reportes
+    ' Declaraciones a nivel de módulo
+    Dim reportePDF As PdfDocument
+    Dim pag As PdfPage
+    Dim graficos As PdfGraphics
+    Dim pos As New PointF(10, 10)
+    Dim ultimaFilaDibujada As Integer = -1
+
+#Region "Obtención de datos"
     Friend Async Function GenerarReporte(desde As Date, hasta As Date, t As DataSet) As Task(Of Cls_ReporteVentas)
         Try
             Dim listaVentas As List(Of Cls_DatosFactura) = Await ObtenerListaVentas(desde, hasta, t)
@@ -139,11 +151,15 @@ Module Md_Reportes
                                       Using db As New SQLiteConnection(GetConnectionString())
                                           db.Open()
                                           Dim orderByProperty As String
-                                          If orderBy = 1 Then
-                                              orderByProperty = "unidadesVendidas"
-                                          ElseIf orderBy = 2 Then
-                                              orderByProperty = "total"
-                                          End If
+                                          Select Case orderBy
+                                              Case 1
+                                                  orderByProperty = "unidadesVendidas"
+                                              Case 2
+                                                  orderByProperty = "total"
+                                              Case Else
+                                                  orderByProperty = "total"
+                                          End Select
+
                                           Dim consulta As String = "SELECT COUNT(fp.ID_Producto) AS unidadesVendidas, p.nombre, SUM(fp.precio_venta * fp.cant) As total " &
                                                                "FROM factura f " &
                                                                "INNER JOIN factura_producto fp ON f.ID = fp.ID_Factura " &
@@ -178,30 +194,150 @@ Module Md_Reportes
                                   Return listProductosMasVendidos
                               End Function)
     End Function
+#End Region
 
-    Private Async Sub Crear_PDF_ReporteVentas(desde As Date, hasta As Date)
+    Friend Async Sub Crear_PDF_ReporteVentas(desde As Date, hasta As Date)
+        pos = New PointF(10, 10)
         'Se obtiene la información relevante de la base de datos
         Dim reporte As Cls_ReporteVentas = Await GenerarReporte(desde, hasta, T1)
+        Dim cultura As New CultureInfo("es-CR")
+
+        Dim listaFiltrada = reporte.ListaVentas.Select(Function(venta) New With {
+                .NumFactura = venta.NumFactura,
+                .Fecha = venta.Fecha,
+                .Cajero = venta.Cajero,
+                .Cliente = venta.Cliente,
+                .TipoPago = venta.TipoPago,
+                .TotalCaja = venta.TotalCaja.ToString("C", New CultureInfo("es-CR"))})
+
+        'Se obtienen los datos de la sucursal
+        Dim sucursal As Cls_Sucursal = Await GetInfoSucursal()
+        ' 2. Se verifica si la ruta del logo de la sucursal existe en el disco
+        If String.IsNullOrEmpty(sucursal.logo) OrElse Not System.IO.File.Exists(sucursal.logo) Then
+            ' Si la ruta no es válida, se construye una ruta dinámica para el logo de respaldo
+            Dim rutaBase As String = Application.StartupPath
+            Dim rutaRecursos As String = System.IO.Path.Combine(rutaBase, "recursos")
+            sucursal.logo = System.IO.Path.Combine(rutaRecursos, "logoCompletoSFCommon.jpg")
+        End If
+
+        Dim logo As New PdfBitmap(sucursal.logo)
+
+        'Se establecen las variables necesarias para guardar el archivo
+        Dim rutaPerfil As String = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+        Dim rutaDescargas As String = Path.Combine(rutaPerfil, "Downloads")
+        Dim rutaCompleta As String = Path.Combine(rutaDescargas, $"ReporteDeVentas{Date.Now:yyyyMMddHHmmss}.pdf")
 
         ' 1. Define diferentes estilos de fuente
         Dim fontTitulo As New PdfStandardFont(PdfFontFamily.Courier, 18, PdfFontStyle.Bold)
+        Dim fontSubTitulo As New PdfStandardFont(PdfFontFamily.Courier, 14, PdfFontStyle.Bold)
         Dim fontNormal As New PdfStandardFont(PdfFontFamily.Courier, 10)
         Dim fontNormalNegrita As New PdfStandardFont(PdfFontFamily.Courier, 10, PdfFontStyle.Bold)
 
-        '2. Se define el punto de incio de nuestros elementos en el documento
-        Dim yPoint As Single = 20
+        'Crea y define el objeto para la alineación
+        Dim fCentrado As New PdfStringFormat With {
+            .Alignment = PdfTextAlignment.Center
+        }
+        Dim fIzquierda As New PdfStringFormat With {
+            .Alignment = PdfTextAlignment.Left
+        }
+        Dim fDerecha As New PdfStringFormat With {
+            .Alignment = PdfTextAlignment.Right
+        }
+        Dim fJustify As New PdfStringFormat With {
+            .Alignment = PdfTextAlignment.Justify
+        }
 
-        ' Se crea un elemento PdfTextElement para los elementos que necesitamos mostrar como texto
-        'Titulo
-        Dim tituloElement As New PdfTextElement("REPORTE DE VENTAS", fontTitulo, PdfBrushes.Black)
-        'Fecha de emisión
-        Dim FechaEmisionElement As New PdfTextElement($"Fecha de emisión {desde.Date.ToLongDateString()} - {hasta.Date.ToLongDateString()}")
+        reportePDF = New PdfDocument()
+        pag = reportePDF.Pages.Add()
+        graficos = pag.Graphics
 
-        Using reportePDF As New PdfDocument()
-            ' Se pinta el título del reporte al documento
+        'Se definen las dimensiones de la imagen
+        Dim dimensionesLogo As Single = 60
+        Dim tamañoLogo As New SizeF(dimensionesLogo, dimensionesLogo)
+        Dim areaLogo As New RectangleF(pos, tamañoLogo)
+        'Se dibuja la imagen en el reporte
+        graficos.DrawImage(logo, areaLogo)
 
-        End Using
+        'Se aumenta la posición en el eje Y a 30
+        pos.Y += 20
+
+        'Se dibuja el título
+        Dim posTitulo As New PointF(pag.Size.Width / 2, pos.Y)
+        graficos.DrawString("REPORTE DE VENTAS", fontTitulo, PdfBrushes.Black, posTitulo, fCentrado)
+
+        'Se aumenta la posición en el eje Y a 80
+        pos.Y += 50
+
+        'Se muestra el total de ventas
+        graficos.DrawString($"Total de ventas: {reporte.total_ventas.ToString("C", New CultureInfo("es-CR"))}", fontNormalNegrita, PdfBrushes.Black, pos, fIzquierda)
+
+        Dim posNumVentas As New PointF(pag.Size.Width - 210, pos.Y)
+        'Se muestra el numero de ventas
+        graficos.DrawString($"Numero de ventas: {reporte.num_ventas:#,##}", fontNormalNegrita, PdfBrushes.Black, posNumVentas, fDerecha)
+
+        pos.Y += 20
+        graficos.DrawString($"Ventas en tarjeta: {reporte.ventas_tarjeta.ToString("C", New CultureInfo("es-CR"))}", fontNormalNegrita, PdfBrushes.Black, pos, fIzquierda)
+
+        Dim posVentasEfectivo As New PointF(pag.Size.Width - 150, pos.Y)
+        'Se muestra el numero de ventas
+        graficos.DrawString($"Ventas en efectivo: {reporte.ventas_efectivo.ToString("C", New CultureInfo("es-CR"))}", fontNormalNegrita, PdfBrushes.Black, posVentasEfectivo, fDerecha)
+
+        pos.Y += 20
+        graficos.DrawString($"Producto más vendido: {reporte.ProductoMasVendido.Nombre}", fontNormalNegrita, PdfBrushes.Black, pos, fIzquierda)
+
+        pos.Y += 20
+        graficos.DrawString($"Cantidad vendida: {reporte.ProductoMasVendido.Cantidad:#,##}", fontNormalNegrita, PdfBrushes.Black, pos, fIzquierda)
+
+        Dim posTotalVentasProd As New PointF(pag.Size.Width - 335, pos.Y)
+        graficos.DrawString($"Total vendido: {reporte.ProductoMasVendido.Total.ToString("C", New CultureInfo("es-CR"))}", fontNormalNegrita, PdfBrushes.Black, posTotalVentasProd, fIzquierda)
+
+        pos.Y += 30
+        graficos.DrawString($"Lista de ventas", fontSubTitulo, PdfBrushes.Black, pos, fIzquierda)
+
+        pos.Y += 20
+
+        If listaFiltrada IsNot Nothing And listaFiltrada.Count > 0 Then
+            Dim gridVentas As New PdfGrid With {
+            .DataSource = listaFiltrada
+        }
+            For Each celda As PdfGridCell In gridVentas.Headers(0).Cells
+                celda.Style.Font = fontNormalNegrita
+                celda.Style.StringFormat = fCentrado
+            Next
+            gridVentas.RepeatHeader = True
+
+            ' Se define un formato de paginación
+            Dim formatoDisposicion As New PdfGridLayoutFormat With {
+                .Layout = PdfLayoutType.Paginate,
+                .Break = PdfLayoutBreakType.FitPage
+            }
+            ' Se dibuja el grid, pasándole la posición inicial y el formato de paginación
+            ' El método Draw se encarga de crear las nuevas páginas automáticamente
+            gridVentas.Draw(pag, pos.X, pos.Y, formatoDisposicion)
+        End If
+
+        reportePDF.Save(rutaCompleta)
+
+        Dim resultado As DialogResult = MsgBox($"Archivo creado exitosamente en la ruta: {rutaCompleta}" & vbCrLf & "¿Desea abrir el archivo?", vbOKCancel, "¿Desea abrir el archivo?")
+        If resultado = DialogResult.OK Then
+            ' Abre el archivo PDF con el programa predeterminado del sistema
+            System.Diagnostics.Process.Start(rutaCompleta)
+        End If
+
     End Sub
+
+
+    Private Async Function GetInfoSucursal() As Task(Of Cls_Sucursal)
+        Return Await Task.Run(Function()
+                                  Dim consulta As String = "SELECT nombre, logo FROM sucursal;"
+                                  Cargar_Tabla(T, consulta)
+                                  Dim suc As New Cls_Sucursal With {
+                                      .Nombre = T.Tables(0).Rows(0).Item(0),
+                                      .logo = T.Tables(0).Rows(0).Item(1)
+                                  }
+                                  Return suc
+                              End Function)
+    End Function
 
 #Region "Cierre de caja"
 

--- a/SistemaFacturación/My Project/Application.Designer.vb
+++ b/SistemaFacturación/My Project/Application.Designer.vb
@@ -26,8 +26,19 @@ Namespace My
             MyBase.New(Global.Microsoft.VisualBasic.ApplicationServices.AuthenticationMode.Windows)
             Me.IsSingleInstance = false
             Me.EnableVisualStyles = true
-            Me.SaveMySettingsOnExit = true
-            Me.ShutDownStyle = Global.Microsoft.VisualBasic.ApplicationServices.ShutdownMode.AfterAllFormsClose
+            Me.SaveMySettingsOnExit = True
+            Me.ShutdownStyle = Global.Microsoft.VisualBasic.ApplicationServices.ShutdownMode.AfterAllFormsClose
+
+            ' Lee la clave de licencia de la variable de entorno
+            Dim syncfusionKey As String = Environment.GetEnvironmentVariable("SYNCFUSION_LICENSE_KEY")
+
+            ' Registra la licencia solo si la clave existe
+            If Not String.IsNullOrEmpty(syncfusionKey) Then
+                Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense(syncfusionKey)
+            Else
+                System.Windows.Forms.MessageBox.Show("Syncfusion license key not found. Please set the SYNCFUSION_LICENSE_KEY environment variable.", "License Error", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error)
+            End If
+
         End Sub
         
         <Global.System.Diagnostics.DebuggerStepThroughAttribute()>  _

--- a/SistemaFacturación/P_ReporteVentas.vb
+++ b/SistemaFacturación/P_ReporteVentas.vb
@@ -250,9 +250,11 @@ Public Class P_ReporteVentas
     End Sub
 
     Private Sub BTN_GenerarReporteVentaPDF_Click(sender As Object, e As EventArgs) Handles BTN_GenerarReporteVentaPDF.Click
-        'If MsgBox("Desea generar el reporte con la información indicada?") = DialogResult.OK Then
-        '    Md_Reportes.Crear_PDF_ReporteVentas(DTP_Desde.Value, DTP_Hasta.Value)
-        'End If
+        Dim resultado As DialogResult = MsgBox($"Desea generar el reporte de ventas en este rango: {DTP_Desde.Value:dd MMM yyyy} - {DTP_Hasta.Value:dd MMM yyyy}",
+                                               vbOKCancel, "Confirmación")
+        If resultado = DialogResult.OK Then
+            Md_Reportes.Crear_PDF_ReporteVentas(DTP_Desde.Value, DTP_Hasta.Value)
+        End If
     End Sub
 
 #End Region

--- a/SistemaFacturación/P_TerminarVenta.Designer.vb
+++ b/SistemaFacturación/P_TerminarVenta.Designer.vb
@@ -186,7 +186,7 @@ Partial Class P_TerminarVenta
         '
         Me.TXT_EVuelto.BorderRadius = 20
         Me.TXT_EVuelto.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.TXT_EVuelto.DefaultText = ""
+        Me.TXT_EVuelto.DefaultText = "0"
         Me.TXT_EVuelto.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
         Me.TXT_EVuelto.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
         Me.TXT_EVuelto.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))

--- a/SistemaFacturación/SistemaFacturación.vbproj
+++ b/SistemaFacturación/SistemaFacturación.vbproj
@@ -114,27 +114,27 @@
     <Reference Include="Guna.UI2, Version=2.0.4.6, Culture=neutral, PublicKeyToken=8b9d14aa5142e261, processorArchitecture=MSIL">
       <HintPath>..\packages\Guna.UI2.WinForms.2.0.4.6\lib\net472\Guna.UI2.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=9.0.0.9, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.9.0.9\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.6.0.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=9.0.0.9, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.9.0.9\lib\net462\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.6.0.0\lib\net461\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=9.0.0.9, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.9.0.9\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.6.0.0\lib\net461\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=9.0.0.9, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.9.0.9\lib\net462\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\lib\net461\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=9.0.0.9, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.9.0.9\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.6.0.0\lib\net461\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=9.0.0.9, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.9.0.9\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.6.0.0\lib\net461\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=9.0.0.9, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.9.0.9\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.11.2.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.2\lib\net40\Mono.Cecil.dll</HintPath>
@@ -160,8 +160,8 @@
     <Reference Include="Syncfusion.BulletGraph.Windows, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL" />
     <Reference Include="Syncfusion.Chart.Base, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     <Reference Include="Syncfusion.Chart.Windows, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL" />
-    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.18.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.31.1.18\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.31.1.19\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.Core.WinForms, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     <Reference Include="Syncfusion.Diagram.Base, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
@@ -171,12 +171,12 @@
     <Reference Include="Syncfusion.Grid.Grouping.Windows, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL" />
     <Reference Include="Syncfusion.Grid.Windows, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     <Reference Include="Syncfusion.Grouping.Base, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
-    <Reference Include="Syncfusion.Licensing, Version=31.1462.18.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.31.1.18\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.19.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.31.1.19\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.Linq.Base, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
-    <Reference Include="Syncfusion.Pdf.Base, Version=31.1462.18.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Pdf.WinForms.31.1.18\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Pdf.Base, Version=31.1462.19.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Pdf.WinForms.31.1.19\lib\net462\Syncfusion.Pdf.Base.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.PivotAnalysis.Base, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
     <Reference Include="Syncfusion.PivotAnalysis.Windows, Version=30.2462.4.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL" />
@@ -192,8 +192,8 @@
     <Reference Include="System">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\System.dll</HintPath>
     </Reference>
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -209,29 +209,26 @@
     </Reference>
     <Reference Include="System.Deployment" />
     <Reference Include="System.Design" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.6.0.0\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=9.0.0.9, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.9.0.9\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Runtime.Serialization.Formatters.Soap" />
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
@@ -878,12 +875,12 @@
       <ErrorText>Este proyecto hace referencia a los paquetes NuGet que faltan en este equipo. Use la restauración de paquetes NuGet para descargarlos. Para obtener más información, consulte http://go.microsoft.com/fwlink/?LinkID=322105. El archivo que falta es {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.119.0\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.119.0\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets'))" />
     <Error Condition="!Exists('..\packages\squirrel.windows.2.0.1\build\squirrel.windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\squirrel.windows.2.0.1\build\squirrel.windows.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.5.1\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.5.1\build\EntityFramework.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.5.1\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.5.1\build\EntityFramework.targets'))" />
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets'))" />
   </Target>
   <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.119.0\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.119.0\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
-  <Import Project="..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
   <Import Project="..\packages\EntityFramework.6.5.1\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.5.1\build\EntityFramework.targets')" />
+  <Import Project="..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" />
 </Project>

--- a/SistemaFacturación/packages.config
+++ b/SistemaFacturación/packages.config
@@ -3,29 +3,29 @@
   <package id="DeltaCompressionDotNet" version="1.1.0" targetFramework="net472" />
   <package id="EntityFramework" version="6.5.1" targetFramework="net472" />
   <package id="Guna.UI2.WinForms" version="2.0.4.6" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="6.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging" version="6.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options" version="6.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="6.0.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.9" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="9.0.9" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="9.0.9" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging" version="9.0.9" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="9.0.9" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="9.0.9" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="9.0.9" targetFramework="net472" />
   <package id="Mono.Cecil" version="0.11.2" targetFramework="net472" />
   <package id="SharpCompress" version="0.17.1" targetFramework="net472" />
   <package id="squirrel.windows" version="2.0.1" targetFramework="net472" />
   <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.119.0" targetFramework="net472" />
-  <package id="Syncfusion.Compression.Base" version="31.1.18" targetFramework="net472" />
-  <package id="Syncfusion.Licensing" version="31.1.18" targetFramework="net472" />
-  <package id="Syncfusion.Pdf.WinForms" version="31.1.18" targetFramework="net472" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="Syncfusion.Compression.Base" version="31.1.19" targetFramework="net472" />
+  <package id="Syncfusion.Licensing" version="31.1.19" targetFramework="net472" />
+  <package id="Syncfusion.Pdf.WinForms" version="31.1.19" targetFramework="net472" />
+  <package id="System.Buffers" version="4.6.1" targetFramework="net472" />
   <package id="System.Data.SQLite" version="1.0.119.0" targetFramework="net472" />
   <package id="System.Data.SQLite.Core" version="1.0.119.0" targetFramework="net472" />
   <package id="System.Data.SQLite.EF6" version="1.0.119.0" targetFramework="net472" />
   <package id="System.Data.SQLite.Linq" version="1.0.119.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="9.0.9" targetFramework="net472" />
+  <package id="System.Memory" version="4.6.3" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.6.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
# Nuevo
## Descarga en PDF de los reportes de ventas
- Se desarrollo la funcionalidad de la creación de documentos PDF de los reportes de ventas, estos muestran la misma información que se muestra en la pestaña de reportes de ventas pero con la funcionalidad de poder ser llevados a cualquier parte de forma más sencilla
- Los documentos PDF descargados de esta manera por defecto se exportaran en la pestaña de descargas del dispositivo (En el futuro se habilitará la configuración de estos para definir donde realizar la exportación)

# Bug Fix
## Impresiones
- Se arregló un error por el que algunas consultas de información en la base de datos se hacían con información erronea la cual provocaba varios errores a la hora de imprimir luego de los cambios realizados en pull requests pasados
- Se arregló un error en el que las variables que almacenan la información de la factura no se reiniciaban con cada factura imprimiendo de forma acumulada las facuturas
- En caso de que la factura no contara con un comentario antes el programa se caís al no tener referencia de este, ahora se mejoró este proceso manejando este caso en el que la factura no cuente con un comentario

# Dependencias
Se actualizaron la mayoría de dependencias, esperando por probrar los efectos de la actualización del paquete de SQLite a la 2.0.2 para mejorar el trabajo con la base de datos en la aplicación