### PR TITLE
Fix error de cierre de la aplicación al regresar de ver los datos de las facturas y fix errro cantidad 0 en busqueda de productos en caja

### DIFF
--- a/HISTORICRELREASENOTES.md
+++ b/HISTORICRELREASENOTES.md
@@ -1,3 +1,11 @@
+# Notas del parche versión 3.0.2 (19 de oct de 2025)
+
+Esta actualización busca resolver 2 erorres bastante molestos y problemáticos con la aplicación despues de las versiones anteriores
+
+## BugFix
+- Se arregló un error en la caja en el que al buscar un producto se colocaba por defecto el valor de 0, lo cual era incorrecto, ahora ya muestra el número 1 correctamente
+- Se arregló un error en el que en el momento en el que se preionaba el botón de regresar en la pestaña de ver datos de las factura se cerraba la aplicación por error
+
 # Notas del parche versión 3.0.1 (16 de oct de 2025)
 
 Esta actualización presenta mejorar y bugfix importantes en el funcionamiento de la aplicación, principalmente en el manejo de la instancia única de la aplicación, su cierre ya la conexión con el servidor de git

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,14 +1,9 @@
-# Notas del parche versión 3.0.1 (16 de oct de 2025)
+# Notas del parche versión 3.0.2 (19 de oct de 2025)
 
-Esta actualización presenta mejorar y bugfix importantes en el funcionamiento de la aplicación, principalmente en el manejo de la instancia única de la aplicación, su cierre ya la conexión con el servidor de git
+Esta actualización busca resolver 2 erorres bastante molestos y problemáticos con la aplicación despues de las versiones anteriores
 
-## Nuevo
-
-### Configuraciones
-- Se agregaron 2 botones en la pestaña de información de las configuraciones, uno te permite ver la lista de cambios de las actualizaciones, principalmente de la más reciente, desde el directorio de git del proyecto, mientras que el botón que dice "Código fuente" te redirige al repositorio de github en el navegador
 ## BugFix
+- Se arregló un error en la caja en el que al buscar un producto se colocaba por defecto el valor de 0, lo cual era incorrecto, ahora ya muestra el número 1 correctamente
+- Se arregló un error en el que en el momento en el que se preionaba el botón de regresar en la pestaña de ver datos de las factura se cerraba la aplicación por error
 
-### Generales
-- Se arregló un error en ran parte de las pestañas que provocaba que la aplicación no se cerrara de forma correcta y quedara trabajando en segundo plano, ahora al presionar cualquier botón que cierre la aplicación por completo esta ya se cerrará de forma correcta, impidiendo así que en condiciones normales haya problemas con la instancia única de la aplicación.
-- Se arregló el título en la pestaña de cierre de caja
      

--- a/SistemaFacturación/Forms/Busqueda/B_Producto.vb
+++ b/SistemaFacturación/Forms/Busqueda/B_Producto.vb
@@ -24,7 +24,7 @@ Namespace SistemaFacturacion.Forms.Busqueda
             TXT_BuscarProd.Text = producto.Producto
             TXT_codigo.Text = producto.Codigo
             TXT_Nombre.Text = producto.Producto
-            TXT_CantProd.Text = producto.Cantidad
+            TXT_CantProd.Text = If(producto.Cantidad <= 1, 1, producto.Cantidad)
             TXT_Precio.Text = producto.Precio
         End Sub
 
@@ -168,7 +168,7 @@ Namespace SistemaFacturacion.Forms.Busqueda
                 producto.Cantidad += 1
                 TXT_CantProd.Text = producto.Cantidad
             Catch ex As Exception
-
+                MsgError("Cantidad inválida.")
             End Try
 
         End Sub
@@ -179,9 +179,12 @@ Namespace SistemaFacturacion.Forms.Busqueda
                 If producto.Cantidad >= 1 Then
                     producto.Cantidad -= 1
                     TXT_CantProd.Text = producto.Cantidad
+                Else
+                    producto.Cantidad = 0
+                    TXT_CantProd.Text = producto.Cantidad
                 End If
             Catch ex As Exception
-
+                MsgError("Cantidad inválida.")
             End Try
         End Sub
 

--- a/SistemaFacturación/Forms/Caja/P_DatosFactura.vb
+++ b/SistemaFacturación/Forms/Caja/P_DatosFactura.vb
@@ -5,6 +5,7 @@ Imports SistemaFacturaciónCommon.SistemaFacturacion.Modules
 Namespace SistemaFacturacion.Forms.Caja
     Public Class P_DatosFactura
         Private Sub BTN_RegresarPed_Click(sender As Object, e As EventArgs) Handles BTN_RegresarPed.Click
+            isNavigating = True
             Me.DialogResult = DialogResult.Cancel
         End Sub
 

--- a/SistemaFacturación/My Project/AssemblyInfo.vb
+++ b/SistemaFacturación/My Project/AssemblyInfo.vb
@@ -28,5 +28,5 @@ Imports System.Runtime.InteropServices
 '      Revisión
 '
 
-<Assembly: AssemblyVersion("3.0.1")>
-<Assembly: AssemblyFileVersion("3.0.1")>
+<Assembly: AssemblyVersion("3.0.2")>
+<Assembly: AssemblyFileVersion("3.0.2")>

--- a/SistemaFacturación/SistemaFacturación.vbproj
+++ b/SistemaFacturación/SistemaFacturación.vbproj
@@ -35,7 +35,7 @@
     <WebPage>publish.htm</WebPage>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>3.0.1.0</ApplicationVersion>
+    <ApplicationVersion>3.0.2.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <CreateDesktopShortcut>true</CreateDesktopShortcut>
     <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
# BugFix
- Se arregló un error en la caja en el que al buscar un producto se colocaba por defecto el valor de 0, lo cual era incorrecto, ahora ya muestra el número 1 correctamente
- Se arregló un error en el que en el momento en el que se preionaba el botón de regresar en la pestaña de ver datos de las factura se cerraba la aplicación por error