### PR TITLE
Bugfix #68, #69, #70

### DIFF
--- a/HISTORICRELREASENOTES.md
+++ b/HISTORICRELREASENOTES.md
@@ -1,3 +1,24 @@
+# Notas del parche versión 3.0.3 (20 de oct de 2025)
+
+Esta actualización busca resolver algunos problemas identificados anteriormente en varias partes de la aplicación
+
+## Nuevo
+Closes #70
+- Se agregó un nuevo filtro en la pestaña de consulta de productos, esta ahora ter permite limitar la cantidad de productos que se cargan buscando hacer que estos se carguen de forma más rápido resolviendo el problema de la duración inicial de carga al ingresar a la pestaña de consulta (Este cambio tambipen aplica para la pestaña de busqueda de productos de la caja)
+
+## BugFix
+
+### 1. Terminar venta
+Closes #69
+- Se revirtió el cambio del la caja de texto numericas a como estaba antes, ahora estas muestran en tiempo real el valor del vuelto sin necesitar de presionar nada y además ya evitan totalmente el ingreso de cualquier tipo de caracter que no sea numérico
+- Se mejoró la eficiencia y robustes de los procesos de calculo de vueltos y restantes en la pestaña de terminar venta
+
+### 2. Reimpresión de facturas
+Closes #68
+- Se arregló un error en el que al presionar el botón de "Reimprimir más reciente" en la pestaña de reimpresiones se mostraba un error y no se podía imprimir
+- Se arregló un error relacionado a la selección de la fila con la factura a imprimir en el que a veces al selecionar la primer fila esta no se imprimía correctamente
+- Se eliminó el preview que se generaba al terminar la factura ya que en producción no se consideró necesario ya que este se imprimiría en todo caso
+
 # Notas del parche versión 3.0.2 (19 de oct de 2025)
 
 Esta actualización busca resolver 2 erorres bastante molestos y problemáticos con la aplicación despues de las versiones anteriores

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,9 +1,21 @@
-# Notas del parche versión 3.0.2 (19 de oct de 2025)
+# Notas del parche versión 3.0.3 (20 de oct de 2025)
 
-Esta actualización busca resolver 2 erorres bastante molestos y problemáticos con la aplicación despues de las versiones anteriores
+Esta actualización busca resolver algunos problemas identificados anteriormente en varias partes de la aplicación
+
+## Nuevo
+Closes #70
+- Se agregó un nuevo filtro en la pestaña de consulta de productos, esta ahora ter permite limitar la cantidad de productos que se cargan buscando hacer que estos se carguen de forma más rápido resolviendo el problema de la duración inicial de carga al ingresar a la pestaña de consulta (Este cambio tambipen aplica para la pestaña de busqueda de productos de la caja)
 
 ## BugFix
-- Se arregló un error en la caja en el que al buscar un producto se colocaba por defecto el valor de 0, lo cual era incorrecto, ahora ya muestra el número 1 correctamente
-- Se arregló un error en el que en el momento en el que se preionaba el botón de regresar en la pestaña de ver datos de las factura se cerraba la aplicación por error
 
+### 1. Terminar venta
+Closes #69
+- Se revirtió el cambio del la caja de texto numericas a como estaba antes, ahora estas muestran en tiempo real el valor del vuelto sin necesitar de presionar nada y además ya evitan totalmente el ingreso de cualquier tipo de caracter que no sea numérico
+- Se mejoró la eficiencia y robustes de los procesos de calculo de vueltos y restantes en la pestaña de terminar venta
+
+### 2. Reimpresión de facturas
+Closes #68
+- Se arregló un error en el que al presionar el botón de "Reimprimir más reciente" en la pestaña de reimpresiones se mostraba un error y no se podía imprimir
+- Se arregló un error relacionado a la selección de la fila con la factura a imprimir en el que a veces al selecionar la primer fila esta no se imprimía correctamente
+- Se eliminó el preview que se generaba al terminar la factura ya que en producción no se consideró necesario ya que este se imprimiría en todo caso
      

--- a/SistemaFacturación/Forms/Busqueda/B_Producto.Designer.vb
+++ b/SistemaFacturación/Forms/Busqueda/B_Producto.Designer.vb
@@ -25,10 +25,10 @@
         <System.Diagnostics.DebuggerStepThrough()>
         Private Sub InitializeComponent()
             Me.components = New System.ComponentModel.Container()
-            Dim DataGridViewCellStyle1 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-            Dim DataGridViewCellStyle2 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-            Dim DataGridViewCellStyle3 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-            Dim DataGridViewCellStyle4 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+            Dim DataGridViewCellStyle17 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+            Dim DataGridViewCellStyle18 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+            Dim DataGridViewCellStyle19 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+            Dim DataGridViewCellStyle20 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(B_Producto))
             Me.Guna2BorderlessForm1 = New Guna.UI2.WinForms.Guna2BorderlessForm(Me.components)
             Me.LBL_IDProd = New System.Windows.Forms.Label()
@@ -49,9 +49,15 @@
             Me.Label3 = New System.Windows.Forms.Label()
             Me.BTN_MenosCant = New Guna.UI2.WinForms.Guna2CircleButton()
             Me.BTN_MasCant = New Guna.UI2.WinForms.Guna2CircleButton()
+            Me.GBX_Filter = New Guna.UI2.WinForms.Guna2GroupBox()
+            Me.RDB_All = New Guna.UI2.WinForms.Guna2RadioButton()
+            Me.RDB_200 = New Guna.UI2.WinForms.Guna2RadioButton()
+            Me.RDB_100 = New Guna.UI2.WinForms.Guna2RadioButton()
+            Me.RDB_500 = New Guna.UI2.WinForms.Guna2RadioButton()
             CType(Me.Guna2PictureBox2, System.ComponentModel.ISupportInitialize).BeginInit()
             CType(Me.DGV_BProd, System.ComponentModel.ISupportInitialize).BeginInit()
             Me.Guna2Panel1.SuspendLayout()
+            Me.GBX_Filter.SuspendLayout()
             Me.SuspendLayout()
             '
             'Guna2BorderlessForm1
@@ -66,7 +72,7 @@
             Me.LBL_IDProd.AutoSize = True
             Me.LBL_IDProd.Font = New System.Drawing.Font("Britannic Bold", 15.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.LBL_IDProd.ForeColor = System.Drawing.Color.White
-            Me.LBL_IDProd.Location = New System.Drawing.Point(842, 385)
+            Me.LBL_IDProd.Location = New System.Drawing.Point(843, 398)
             Me.LBL_IDProd.Name = "LBL_IDProd"
             Me.LBL_IDProd.Size = New System.Drawing.Size(16, 23)
             Me.LBL_IDProd.TabIndex = 96
@@ -78,7 +84,7 @@
             Me.Label1.AutoSize = True
             Me.Label1.Font = New System.Drawing.Font("Britannic Bold", 15.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label1.ForeColor = System.Drawing.Color.White
-            Me.Label1.Location = New System.Drawing.Point(530, 238)
+            Me.Label1.Location = New System.Drawing.Point(531, 251)
             Me.Label1.Name = "Label1"
             Me.Label1.Size = New System.Drawing.Size(79, 23)
             Me.Label1.TabIndex = 93
@@ -97,9 +103,8 @@
             Me.TXT_codigo.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.TXT_codigo.ForeColor = System.Drawing.Color.Black
             Me.TXT_codigo.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_codigo.Location = New System.Drawing.Point(615, 228)
+            Me.TXT_codigo.Location = New System.Drawing.Point(616, 241)
             Me.TXT_codigo.Name = "TXT_codigo"
-            Me.TXT_codigo.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_codigo.PlaceholderText = ""
             Me.TXT_codigo.ReadOnly = True
             Me.TXT_codigo.SelectedText = ""
@@ -163,10 +168,9 @@
             Me.TXT_BuscarProd.IconRightSize = New System.Drawing.Size(40, 40)
             Me.TXT_BuscarProd.Location = New System.Drawing.Point(23, 152)
             Me.TXT_BuscarProd.Name = "TXT_BuscarProd"
-            Me.TXT_BuscarProd.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_BuscarProd.PlaceholderText = "Buscar producto"
             Me.TXT_BuscarProd.SelectedText = ""
-            Me.TXT_BuscarProd.Size = New System.Drawing.Size(921, 42)
+            Me.TXT_BuscarProd.Size = New System.Drawing.Size(716, 42)
             Me.TXT_BuscarProd.TabIndex = 87
             '
             'Guna2PictureBox2
@@ -193,9 +197,8 @@
             Me.TXT_Nombre.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.TXT_Nombre.ForeColor = System.Drawing.Color.Black
             Me.TXT_Nombre.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_Nombre.Location = New System.Drawing.Point(615, 296)
+            Me.TXT_Nombre.Location = New System.Drawing.Point(616, 309)
             Me.TXT_Nombre.Name = "TXT_Nombre"
-            Me.TXT_Nombre.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_Nombre.PlaceholderText = ""
             Me.TXT_Nombre.ReadOnly = True
             Me.TXT_Nombre.ScrollBars = System.Windows.Forms.ScrollBars.Horizontal
@@ -208,7 +211,7 @@
             Me.Label2.AutoSize = True
             Me.Label2.Font = New System.Drawing.Font("Britannic Bold", 15.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label2.ForeColor = System.Drawing.Color.White
-            Me.Label2.Location = New System.Drawing.Point(522, 306)
+            Me.Label2.Location = New System.Drawing.Point(523, 319)
             Me.Label2.Name = "Label2"
             Me.Label2.Size = New System.Drawing.Size(87, 23)
             Me.Label2.TabIndex = 95
@@ -219,7 +222,7 @@
             Me.Label4.AutoSize = True
             Me.Label4.Font = New System.Drawing.Font("Britannic Bold", 15.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label4.ForeColor = System.Drawing.Color.White
-            Me.Label4.Location = New System.Drawing.Point(535, 376)
+            Me.Label4.Location = New System.Drawing.Point(536, 389)
             Me.Label4.Name = "Label4"
             Me.Label4.Size = New System.Drawing.Size(75, 23)
             Me.Label4.TabIndex = 100
@@ -238,9 +241,8 @@
             Me.TXT_Precio.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.TXT_Precio.ForeColor = System.Drawing.Color.Black
             Me.TXT_Precio.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_Precio.Location = New System.Drawing.Point(615, 366)
+            Me.TXT_Precio.Location = New System.Drawing.Point(616, 379)
             Me.TXT_Precio.Name = "TXT_Precio"
-            Me.TXT_Precio.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_Precio.PlaceholderText = ""
             Me.TXT_Precio.ReadOnly = True
             Me.TXT_Precio.SelectedText = ""
@@ -262,7 +264,6 @@
             Me.Guna2TextBox1.Location = New System.Drawing.Point(1142, 902)
             Me.Guna2TextBox1.Margin = New System.Windows.Forms.Padding(6)
             Me.Guna2TextBox1.Name = "Guna2TextBox1"
-            Me.Guna2TextBox1.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.Guna2TextBox1.PlaceholderText = ""
             Me.Guna2TextBox1.ReadOnly = True
             Me.Guna2TextBox1.SelectedText = ""
@@ -274,43 +275,43 @@
             Me.DGV_BProd.AllowUserToAddRows = False
             Me.DGV_BProd.AllowUserToDeleteRows = False
             Me.DGV_BProd.AllowUserToResizeRows = False
-            DataGridViewCellStyle1.BackColor = System.Drawing.Color.White
-            DataGridViewCellStyle1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            DataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.ControlText
-            DataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
-            DataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
-            Me.DGV_BProd.AlternatingRowsDefaultCellStyle = DataGridViewCellStyle1
-            DataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-            DataGridViewCellStyle2.BackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-            DataGridViewCellStyle2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            DataGridViewCellStyle2.ForeColor = System.Drawing.Color.White
-            DataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-            DataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-            DataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-            Me.DGV_BProd.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle2
+            DataGridViewCellStyle17.BackColor = System.Drawing.Color.White
+            DataGridViewCellStyle17.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            DataGridViewCellStyle17.ForeColor = System.Drawing.SystemColors.ControlText
+            DataGridViewCellStyle17.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
+            DataGridViewCellStyle17.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
+            Me.DGV_BProd.AlternatingRowsDefaultCellStyle = DataGridViewCellStyle17
+            DataGridViewCellStyle18.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+            DataGridViewCellStyle18.BackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+            DataGridViewCellStyle18.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            DataGridViewCellStyle18.ForeColor = System.Drawing.Color.White
+            DataGridViewCellStyle18.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+            DataGridViewCellStyle18.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+            DataGridViewCellStyle18.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+            Me.DGV_BProd.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle18
             Me.DGV_BProd.ColumnHeadersHeight = 20
-            DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-            DataGridViewCellStyle3.BackColor = System.Drawing.Color.White
-            DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            DataGridViewCellStyle3.ForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
-            DataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
-            DataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
-            DataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
-            Me.DGV_BProd.DefaultCellStyle = DataGridViewCellStyle3
+            DataGridViewCellStyle19.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+            DataGridViewCellStyle19.BackColor = System.Drawing.Color.White
+            DataGridViewCellStyle19.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            DataGridViewCellStyle19.ForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
+            DataGridViewCellStyle19.SelectionBackColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
+            DataGridViewCellStyle19.SelectionForeColor = System.Drawing.Color.FromArgb(CType(CType(71, Byte), Integer), CType(CType(69, Byte), Integer), CType(CType(94, Byte), Integer))
+            DataGridViewCellStyle19.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
+            Me.DGV_BProd.DefaultCellStyle = DataGridViewCellStyle19
             Me.DGV_BProd.GridColor = System.Drawing.Color.FromArgb(CType(CType(231, Byte), Integer), CType(CType(229, Byte), Integer), CType(CType(255, Byte), Integer))
             Me.DGV_BProd.Location = New System.Drawing.Point(23, 210)
             Me.DGV_BProd.MultiSelect = False
             Me.DGV_BProd.Name = "DGV_BProd"
             Me.DGV_BProd.ReadOnly = True
             Me.DGV_BProd.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None
-            DataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-            DataGridViewCellStyle4.BackColor = System.Drawing.Color.White
-            DataGridViewCellStyle4.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            DataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText
-            DataGridViewCellStyle4.SelectionBackColor = System.Drawing.Color.White
-            DataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-            DataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-            Me.DGV_BProd.RowHeadersDefaultCellStyle = DataGridViewCellStyle4
+            DataGridViewCellStyle20.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+            DataGridViewCellStyle20.BackColor = System.Drawing.Color.White
+            DataGridViewCellStyle20.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            DataGridViewCellStyle20.ForeColor = System.Drawing.SystemColors.WindowText
+            DataGridViewCellStyle20.SelectionBackColor = System.Drawing.Color.White
+            DataGridViewCellStyle20.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+            DataGridViewCellStyle20.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+            Me.DGV_BProd.RowHeadersDefaultCellStyle = DataGridViewCellStyle20
             Me.DGV_BProd.RowHeadersVisible = False
             Me.DGV_BProd.Size = New System.Drawing.Size(493, 314)
             Me.DGV_BProd.TabIndex = 106
@@ -359,10 +360,9 @@
             Me.TXT_CantProd.Font = New System.Drawing.Font("Segoe UI", 15.75!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.TXT_CantProd.ForeColor = System.Drawing.Color.Black
             Me.TXT_CantProd.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_CantProd.Location = New System.Drawing.Point(633, 453)
+            Me.TXT_CantProd.Location = New System.Drawing.Point(634, 466)
             Me.TXT_CantProd.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
             Me.TXT_CantProd.Name = "TXT_CantProd"
-            Me.TXT_CantProd.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_CantProd.PlaceholderText = ""
             Me.TXT_CantProd.SelectedText = ""
             Me.TXT_CantProd.Size = New System.Drawing.Size(208, 42)
@@ -374,7 +374,7 @@
             Me.Label3.AutoSize = True
             Me.Label3.Font = New System.Drawing.Font("Britannic Bold", 15.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label3.ForeColor = System.Drawing.Color.White
-            Me.Label3.Location = New System.Drawing.Point(688, 424)
+            Me.Label3.Location = New System.Drawing.Point(689, 437)
             Me.Label3.Name = "Label3"
             Me.Label3.Size = New System.Drawing.Size(92, 23)
             Me.Label3.TabIndex = 106
@@ -392,7 +392,7 @@
             Me.BTN_MenosCant.ForeColor = System.Drawing.Color.Transparent
             Me.BTN_MenosCant.Image = Global.SistemaFacturaciónCommon.My.Resources.Resources.ICO_MinusCol
             Me.BTN_MenosCant.ImageSize = New System.Drawing.Size(50, 50)
-            Me.BTN_MenosCant.Location = New System.Drawing.Point(574, 450)
+            Me.BTN_MenosCant.Location = New System.Drawing.Point(575, 463)
             Me.BTN_MenosCant.Name = "BTN_MenosCant"
             Me.BTN_MenosCant.ShadowDecoration.Mode = Guna.UI2.WinForms.Enums.ShadowMode.Circle
             Me.BTN_MenosCant.Size = New System.Drawing.Size(50, 50)
@@ -414,13 +414,116 @@
             Me.BTN_MasCant.ForeColor = System.Drawing.Color.White
             Me.BTN_MasCant.Image = Global.SistemaFacturaciónCommon.My.Resources.Resources.ICO_MasCol
             Me.BTN_MasCant.ImageSize = New System.Drawing.Size(50, 50)
-            Me.BTN_MasCant.Location = New System.Drawing.Point(850, 450)
+            Me.BTN_MasCant.Location = New System.Drawing.Point(851, 463)
             Me.BTN_MasCant.Name = "BTN_MasCant"
             Me.BTN_MasCant.ShadowDecoration.Mode = Guna.UI2.WinForms.Enums.ShadowMode.Circle
             Me.BTN_MasCant.Size = New System.Drawing.Size(50, 50)
             Me.BTN_MasCant.TabIndex = 109
             Me.BTN_MasCant.TextAlign = System.Windows.Forms.HorizontalAlignment.Left
             Me.BTN_MasCant.TextOffset = New System.Drawing.Point(-6, -5)
+            '
+            'GBX_Filter
+            '
+            Me.GBX_Filter.BorderColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+            Me.GBX_Filter.BorderRadius = 10
+            Me.GBX_Filter.Controls.Add(Me.RDB_All)
+            Me.GBX_Filter.Controls.Add(Me.RDB_200)
+            Me.GBX_Filter.Controls.Add(Me.RDB_100)
+            Me.GBX_Filter.Controls.Add(Me.RDB_500)
+            Me.GBX_Filter.CustomBorderColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+            Me.GBX_Filter.CustomBorderThickness = New System.Windows.Forms.Padding(0, 20, 0, 0)
+            Me.GBX_Filter.FillColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
+            Me.GBX_Filter.Font = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.GBX_Filter.ForeColor = System.Drawing.Color.White
+            Me.GBX_Filter.Location = New System.Drawing.Point(745, 152)
+            Me.GBX_Filter.Name = "GBX_Filter"
+            Me.GBX_Filter.Size = New System.Drawing.Size(199, 74)
+            Me.GBX_Filter.TabIndex = 128
+            Me.GBX_Filter.Text = "Filtro"
+            Me.GBX_Filter.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            Me.GBX_Filter.TextOffset = New System.Drawing.Point(0, -10)
+            '
+            'RDB_All
+            '
+            Me.RDB_All.AutoSize = True
+            Me.RDB_All.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_All.CheckedState.BorderThickness = 0
+            Me.RDB_All.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_All.CheckedState.InnerColor = System.Drawing.Color.White
+            Me.RDB_All.CheckedState.InnerOffset = -4
+            Me.RDB_All.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+            Me.RDB_All.ForeColor = System.Drawing.SystemColors.Control
+            Me.RDB_All.Location = New System.Drawing.Point(101, 45)
+            Me.RDB_All.Name = "RDB_All"
+            Me.RDB_All.Size = New System.Drawing.Size(55, 17)
+            Me.RDB_All.TabIndex = 90
+            Me.RDB_All.Text = "Todos"
+            Me.RDB_All.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
+            Me.RDB_All.UncheckedState.BorderThickness = 2
+            Me.RDB_All.UncheckedState.FillColor = System.Drawing.Color.Transparent
+            Me.RDB_All.UncheckedState.InnerColor = System.Drawing.Color.Transparent
+            '
+            'RDB_200
+            '
+            Me.RDB_200.AutoSize = True
+            Me.RDB_200.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_200.CheckedState.BorderThickness = 0
+            Me.RDB_200.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_200.CheckedState.InnerColor = System.Drawing.Color.White
+            Me.RDB_200.CheckedState.InnerOffset = -4
+            Me.RDB_200.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+            Me.RDB_200.ForeColor = System.Drawing.SystemColors.Control
+            Me.RDB_200.Location = New System.Drawing.Point(101, 25)
+            Me.RDB_200.Name = "RDB_200"
+            Me.RDB_200.Size = New System.Drawing.Size(94, 17)
+            Me.RDB_200.TabIndex = 89
+            Me.RDB_200.Text = "200 Productos"
+            Me.RDB_200.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
+            Me.RDB_200.UncheckedState.BorderThickness = 2
+            Me.RDB_200.UncheckedState.FillColor = System.Drawing.Color.Transparent
+            Me.RDB_200.UncheckedState.InnerColor = System.Drawing.Color.Transparent
+            '
+            'RDB_100
+            '
+            Me.RDB_100.AutoSize = True
+            Me.RDB_100.Checked = True
+            Me.RDB_100.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_100.CheckedState.BorderThickness = 0
+            Me.RDB_100.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_100.CheckedState.InnerColor = System.Drawing.Color.White
+            Me.RDB_100.CheckedState.InnerOffset = -4
+            Me.RDB_100.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+            Me.RDB_100.ForeColor = System.Drawing.SystemColors.Control
+            Me.RDB_100.Location = New System.Drawing.Point(7, 25)
+            Me.RDB_100.Name = "RDB_100"
+            Me.RDB_100.Size = New System.Drawing.Size(94, 17)
+            Me.RDB_100.TabIndex = 88
+            Me.RDB_100.TabStop = True
+            Me.RDB_100.Text = "100 Productos"
+            Me.RDB_100.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
+            Me.RDB_100.UncheckedState.BorderThickness = 2
+            Me.RDB_100.UncheckedState.FillColor = System.Drawing.Color.Transparent
+            Me.RDB_100.UncheckedState.InnerColor = System.Drawing.Color.Transparent
+            '
+            'RDB_500
+            '
+            Me.RDB_500.AutoSize = True
+            Me.RDB_500.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_500.CheckedState.BorderThickness = 0
+            Me.RDB_500.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_500.CheckedState.InnerColor = System.Drawing.Color.White
+            Me.RDB_500.CheckedState.InnerOffset = -4
+            Me.RDB_500.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+            Me.RDB_500.ForeColor = System.Drawing.SystemColors.Control
+            Me.RDB_500.Location = New System.Drawing.Point(7, 45)
+            Me.RDB_500.Name = "RDB_500"
+            Me.RDB_500.Size = New System.Drawing.Size(94, 17)
+            Me.RDB_500.TabIndex = 87
+            Me.RDB_500.Text = "500 Productos"
+            Me.RDB_500.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
+            Me.RDB_500.UncheckedState.BorderThickness = 2
+            Me.RDB_500.UncheckedState.FillColor = System.Drawing.Color.Transparent
+            Me.RDB_500.UncheckedState.InnerColor = System.Drawing.Color.Transparent
             '
             'B_Producto
             '
@@ -430,6 +533,7 @@
             Me.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
             Me.CancelButton = Me.BTN_RegresarPrd
             Me.ClientSize = New System.Drawing.Size(962, 614)
+            Me.Controls.Add(Me.GBX_Filter)
             Me.Controls.Add(Me.TXT_CantProd)
             Me.Controls.Add(Me.Guna2Panel1)
             Me.Controls.Add(Me.Label3)
@@ -455,6 +559,8 @@
             CType(Me.Guna2PictureBox2, System.ComponentModel.ISupportInitialize).EndInit()
             CType(Me.DGV_BProd, System.ComponentModel.ISupportInitialize).EndInit()
             Me.Guna2Panel1.ResumeLayout(False)
+            Me.GBX_Filter.ResumeLayout(False)
+            Me.GBX_Filter.PerformLayout()
             Me.ResumeLayout(False)
             Me.PerformLayout()
 
@@ -479,5 +585,10 @@
         Friend WithEvents Label3 As Label
         Friend WithEvents BTN_MenosCant As Guna.UI2.WinForms.Guna2CircleButton
         Friend WithEvents BTN_MasCant As Guna.UI2.WinForms.Guna2CircleButton
+        Friend WithEvents GBX_Filter As Guna.UI2.WinForms.Guna2GroupBox
+        Friend WithEvents RDB_All As Guna.UI2.WinForms.Guna2RadioButton
+        Friend WithEvents RDB_200 As Guna.UI2.WinForms.Guna2RadioButton
+        Friend WithEvents RDB_100 As Guna.UI2.WinForms.Guna2RadioButton
+        Friend WithEvents RDB_500 As Guna.UI2.WinForms.Guna2RadioButton
     End Class
 End Namespace

--- a/SistemaFacturación/Forms/Busqueda/B_Producto.vb
+++ b/SistemaFacturación/Forms/Busqueda/B_Producto.vb
@@ -50,12 +50,22 @@ Namespace SistemaFacturacion.Forms.Busqueda
                              Else
                                  condicionBusqueda = $"p.codigo LIKE '%{busqueda}%' OR p.nombre LIKE '%{busqueda}%'"
                              End If
+
+                             Dim limit As String = ""
+                             If RDB_100.Checked Then
+                                 limit = " LIMIT 100;"
+                             ElseIf RDB_200.Checked Then
+                                 limit = " LIMIT 200;"
+                             ElseIf RDB_500.Checked Then
+                                 limit = " LIMIT 500;"
+                             End If
+
                              SQL = "SELECT p.ID, p.codigo AS 'Código', p.nombre AS 'Nombre', v.precio_venta AS 'Precio de venta', " &
                                       "CASE WHEN p.variable = 1 THEN 'Si' ELSE 'No' END AS 'Variable' " &
                                       "FROM producto p " &
                                       "LEFT JOIN producto_precioVenta v ON p.ID = v.ID_Producto " &
-                                      "WHERE " & condicionBusqueda &
-                                      " ORDER BY p.codigo ASC;"
+                                      $"WHERE {condicionBusqueda} " &
+                                      $"ORDER BY p.codigo ASC {limit};"
 
                              ' Asegúrate de que el control tiene un identificador de ventana antes de invocar
                              If DGV_BProd.IsHandleCreated Then
@@ -211,6 +221,22 @@ Namespace SistemaFacturacion.Forms.Busqueda
                 TXT_Nombre.Text = ""
                 TXT_Precio.Text = ""
             End Try
+        End Sub
+
+        Private Sub RDB_100_CheckedChanged(sender As Object, e As EventArgs) Handles RDB_100.CheckedChanged
+            REFRESCAR()
+        End Sub
+
+        Private Sub RDB_200_CheckedChanged(sender As Object, e As EventArgs) Handles RDB_200.CheckedChanged
+            REFRESCAR()
+        End Sub
+
+        Private Sub RDB_500_CheckedChanged(sender As Object, e As EventArgs) Handles RDB_500.CheckedChanged
+            REFRESCAR()
+        End Sub
+
+        Private Sub RDB_All_CheckedChanged(sender As Object, e As EventArgs) Handles RDB_All.CheckedChanged
+            REFRESCAR()
         End Sub
     End Class
 End Namespace

--- a/SistemaFacturación/Forms/Caja/P_ReimprimirFact.vb
+++ b/SistemaFacturación/Forms/Caja/P_ReimprimirFact.vb
@@ -184,7 +184,7 @@ Namespace SistemaFacturacion.Forms.Caja
             Try
                 Using conn As New SQLiteConnection(GetConnectionString())
                     conn.Open()
-                    Using cmd As New SQLiteCommand("SELECT MAX(ID) FROM factura WHERE cobrada = 1;", conn)
+                    Using cmd As New SQLiteCommand("SELECT MAX(ID) FROM factura", conn)
                         Dim result = cmd.ExecuteScalar()
                         If result IsNot DBNull.Value Then
                             idFactura = Convert.ToInt32(result)
@@ -207,12 +207,9 @@ Namespace SistemaFacturacion.Forms.Caja
         End Sub
 
         Private Sub MNU_REIMPRIMIR_Click(sender As Object, e As EventArgs) Handles MNU_REIMPRIMIR.Click
-            ' Asume que tienes un DataGridView llamado DGV_Facturas
-            If DGV_ReimprimirFact.CurrentRow IsNot Nothing Then
-                Dim idFactura As Integer = Convert.ToInt32(DGV_ReimprimirFact.CurrentRow.Cells("ID").Value)
-                ' Llamada directa a la función del módulo
-                Md_IMPRIMIR.GENERAR_FACTURA(idFactura, "Comun")
-            End If
+            Dim idFactura As Integer = Convert.ToInt32(DGV_ReimprimirFact.SelectedRows(0).Cells("ID").Value)
+            ' Llamada directa a la función del módulo
+            Md_IMPRIMIR.GENERAR_FACTURA(idFactura, "Comun")
         End Sub
 
         Private Sub MNU_Datos_Click(sender As Object, e As EventArgs) Handles MNU_Datos.Click

--- a/SistemaFacturación/Forms/Caja/P_TerminarVenta.Designer.vb
+++ b/SistemaFacturación/Forms/Caja/P_TerminarVenta.Designer.vb
@@ -28,7 +28,6 @@
         Me.Guna2BorderlessForm1 = New Guna.UI2.WinForms.Guna2BorderlessForm(Me.components)
         Me.TabControlTVenta = New Guna.UI2.WinForms.Guna2TabControl()
         Me.Efectivo = New System.Windows.Forms.TabPage()
-            Me.NUD_ECliente = New Guna.UI2.WinForms.Guna2NumericUpDown()
             Me.BTN_EColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
             Me.TXT_EVuelto = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel2 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -36,7 +35,6 @@
             Me.TXT_ETotal = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel4 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.Tarjeta = New System.Windows.Forms.TabPage()
-            Me.NUD_TCliente = New Guna.UI2.WinForms.Guna2NumericUpDown()
             Me.BTN_TColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
             Me.TXT_TVuelto = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel3 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -44,7 +42,6 @@
             Me.TXT_TTotal = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel6 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.Sinpe = New System.Windows.Forms.TabPage()
-            Me.NUD_SCliente = New Guna.UI2.WinForms.Guna2NumericUpDown()
             Me.BTN_SColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
             Me.TXT_SVuelto = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel7 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -52,7 +49,6 @@
             Me.TXT_STotal = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel9 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.deposito = New System.Windows.Forms.TabPage()
-            Me.NUD_DCliente = New Guna.UI2.WinForms.Guna2NumericUpDown()
             Me.BTN_DColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
             Me.Guna2HtmlLabel11 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.TXT_DVuelto = New Guna.UI2.WinForms.Guna2TextBox()
@@ -60,8 +56,6 @@
             Me.TXT_DTotal = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel12 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.Mixto = New System.Windows.Forms.TabPage()
-            Me.NUD_MTarjeta = New Guna.UI2.WinForms.Guna2NumericUpDown()
-            Me.NUD_MEfectivo = New Guna.UI2.WinForms.Guna2NumericUpDown()
             Me.BTN_RestanteEfectivo = New Guna.UI2.WinForms.Guna2TileButton()
             Me.BTN_RestanteTarjeta = New Guna.UI2.WinForms.Guna2TileButton()
             Me.Guna2HtmlLabel16 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -76,18 +70,18 @@
             Me.TXT_Comentario = New Guna.UI2.WinForms.Guna2TextBox()
             Me.BTN_TVentaImp = New Guna.UI2.WinForms.Guna2Button()
             Me.Guna2Panel1 = New Guna.UI2.WinForms.Guna2Panel()
+            Me.TXT_ECliente = New Guna.UI2.WinForms.Guna2TextBox()
+            Me.TXT_TCliente = New Guna.UI2.WinForms.Guna2TextBox()
+            Me.TXT_SCliente = New Guna.UI2.WinForms.Guna2TextBox()
+            Me.TXT_DCliente = New Guna.UI2.WinForms.Guna2TextBox()
+            Me.TXT_MTarjeta = New Guna.UI2.WinForms.Guna2TextBox()
+            Me.TXT_MEfectivo = New Guna.UI2.WinForms.Guna2TextBox()
             Me.TabControlTVenta.SuspendLayout()
             Me.Efectivo.SuspendLayout()
-            CType(Me.NUD_ECliente, System.ComponentModel.ISupportInitialize).BeginInit()
             Me.Tarjeta.SuspendLayout()
-            CType(Me.NUD_TCliente, System.ComponentModel.ISupportInitialize).BeginInit()
             Me.Sinpe.SuspendLayout()
-            CType(Me.NUD_SCliente, System.ComponentModel.ISupportInitialize).BeginInit()
             Me.deposito.SuspendLayout()
-            CType(Me.NUD_DCliente, System.ComponentModel.ISupportInitialize).BeginInit()
             Me.Mixto.SuspendLayout()
-            CType(Me.NUD_MTarjeta, System.ComponentModel.ISupportInitialize).BeginInit()
-            CType(Me.NUD_MEfectivo, System.ComponentModel.ISupportInitialize).BeginInit()
             Me.Guna2Panel1.SuspendLayout()
             Me.SuspendLayout()
             '
@@ -135,7 +129,7 @@
             'Efectivo
             '
             Me.Efectivo.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-            Me.Efectivo.Controls.Add(Me.NUD_ECliente)
+            Me.Efectivo.Controls.Add(Me.TXT_ECliente)
             Me.Efectivo.Controls.Add(Me.BTN_EColocarTotal)
             Me.Efectivo.Controls.Add(Me.TXT_EVuelto)
             Me.Efectivo.Controls.Add(Me.Guna2HtmlLabel2)
@@ -149,19 +143,6 @@
             Me.Efectivo.Size = New System.Drawing.Size(641, 381)
             Me.Efectivo.TabIndex = 0
             Me.Efectivo.Text = "Efectivo"
-            '
-            'NUD_ECliente
-            '
-            Me.NUD_ECliente.BackColor = System.Drawing.Color.Transparent
-            Me.NUD_ECliente.BorderRadius = 10
-            Me.NUD_ECliente.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.NUD_ECliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-            Me.NUD_ECliente.Location = New System.Drawing.Point(103, 142)
-            Me.NUD_ECliente.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-            Me.NUD_ECliente.Name = "NUD_ECliente"
-            Me.NUD_ECliente.Size = New System.Drawing.Size(439, 42)
-            Me.NUD_ECliente.TabIndex = 108
-            Me.NUD_ECliente.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
             '
             'BTN_EColocarTotal
             '
@@ -194,7 +175,6 @@
             Me.TXT_EVuelto.Location = New System.Drawing.Point(103, 318)
             Me.TXT_EVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_EVuelto.Name = "TXT_EVuelto"
-            Me.TXT_EVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_EVuelto.PlaceholderText = ""
             Me.TXT_EVuelto.ReadOnly = True
             Me.TXT_EVuelto.SelectedText = ""
@@ -242,7 +222,6 @@
             Me.TXT_ETotal.Location = New System.Drawing.Point(103, 43)
             Me.TXT_ETotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_ETotal.Name = "TXT_ETotal"
-            Me.TXT_ETotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_ETotal.PlaceholderText = ""
             Me.TXT_ETotal.ReadOnly = True
             Me.TXT_ETotal.SelectedText = ""
@@ -265,7 +244,7 @@
             'Tarjeta
             '
             Me.Tarjeta.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-            Me.Tarjeta.Controls.Add(Me.NUD_TCliente)
+            Me.Tarjeta.Controls.Add(Me.TXT_TCliente)
             Me.Tarjeta.Controls.Add(Me.BTN_TColocarTotal)
             Me.Tarjeta.Controls.Add(Me.TXT_TVuelto)
             Me.Tarjeta.Controls.Add(Me.Guna2HtmlLabel3)
@@ -278,19 +257,6 @@
             Me.Tarjeta.Size = New System.Drawing.Size(641, 381)
             Me.Tarjeta.TabIndex = 1
             Me.Tarjeta.Text = "Tarjeta"
-            '
-            'NUD_TCliente
-            '
-            Me.NUD_TCliente.BackColor = System.Drawing.Color.Transparent
-            Me.NUD_TCliente.BorderRadius = 10
-            Me.NUD_TCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.NUD_TCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-            Me.NUD_TCliente.Location = New System.Drawing.Point(101, 156)
-            Me.NUD_TCliente.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-            Me.NUD_TCliente.Name = "NUD_TCliente"
-            Me.NUD_TCliente.Size = New System.Drawing.Size(439, 42)
-            Me.NUD_TCliente.TabIndex = 114
-            Me.NUD_TCliente.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
             '
             'BTN_TColocarTotal
             '
@@ -323,7 +289,6 @@
             Me.TXT_TVuelto.Location = New System.Drawing.Point(101, 314)
             Me.TXT_TVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_TVuelto.Name = "TXT_TVuelto"
-            Me.TXT_TVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_TVuelto.PlaceholderText = ""
             Me.TXT_TVuelto.ReadOnly = True
             Me.TXT_TVuelto.SelectedText = ""
@@ -371,7 +336,6 @@
             Me.TXT_TTotal.Location = New System.Drawing.Point(101, 55)
             Me.TXT_TTotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_TTotal.Name = "TXT_TTotal"
-            Me.TXT_TTotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_TTotal.PlaceholderText = ""
             Me.TXT_TTotal.ReadOnly = True
             Me.TXT_TTotal.SelectedText = ""
@@ -394,7 +358,7 @@
             'Sinpe
             '
             Me.Sinpe.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-            Me.Sinpe.Controls.Add(Me.NUD_SCliente)
+            Me.Sinpe.Controls.Add(Me.TXT_SCliente)
             Me.Sinpe.Controls.Add(Me.BTN_SColocarTotal)
             Me.Sinpe.Controls.Add(Me.TXT_SVuelto)
             Me.Sinpe.Controls.Add(Me.Guna2HtmlLabel7)
@@ -407,19 +371,6 @@
             Me.Sinpe.Size = New System.Drawing.Size(641, 381)
             Me.Sinpe.TabIndex = 2
             Me.Sinpe.Text = "Sinpe"
-            '
-            'NUD_SCliente
-            '
-            Me.NUD_SCliente.BackColor = System.Drawing.Color.Transparent
-            Me.NUD_SCliente.BorderRadius = 10
-            Me.NUD_SCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.NUD_SCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-            Me.NUD_SCliente.Location = New System.Drawing.Point(101, 148)
-            Me.NUD_SCliente.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-            Me.NUD_SCliente.Name = "NUD_SCliente"
-            Me.NUD_SCliente.Size = New System.Drawing.Size(439, 42)
-            Me.NUD_SCliente.TabIndex = 120
-            Me.NUD_SCliente.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
             '
             'BTN_SColocarTotal
             '
@@ -452,7 +403,6 @@
             Me.TXT_SVuelto.Location = New System.Drawing.Point(101, 320)
             Me.TXT_SVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_SVuelto.Name = "TXT_SVuelto"
-            Me.TXT_SVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_SVuelto.PlaceholderText = ""
             Me.TXT_SVuelto.ReadOnly = True
             Me.TXT_SVuelto.SelectedText = ""
@@ -500,7 +450,6 @@
             Me.TXT_STotal.Location = New System.Drawing.Point(101, 51)
             Me.TXT_STotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_STotal.Name = "TXT_STotal"
-            Me.TXT_STotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_STotal.PlaceholderText = ""
             Me.TXT_STotal.ReadOnly = True
             Me.TXT_STotal.SelectedText = ""
@@ -523,7 +472,7 @@
             'deposito
             '
             Me.deposito.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-            Me.deposito.Controls.Add(Me.NUD_DCliente)
+            Me.deposito.Controls.Add(Me.TXT_DCliente)
             Me.deposito.Controls.Add(Me.BTN_DColocarTotal)
             Me.deposito.Controls.Add(Me.Guna2HtmlLabel11)
             Me.deposito.Controls.Add(Me.TXT_DVuelto)
@@ -536,19 +485,6 @@
             Me.deposito.Size = New System.Drawing.Size(641, 381)
             Me.deposito.TabIndex = 3
             Me.deposito.Text = "Depósito"
-            '
-            'NUD_DCliente
-            '
-            Me.NUD_DCliente.BackColor = System.Drawing.Color.Transparent
-            Me.NUD_DCliente.BorderRadius = 10
-            Me.NUD_DCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.NUD_DCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-            Me.NUD_DCliente.Location = New System.Drawing.Point(101, 146)
-            Me.NUD_DCliente.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-            Me.NUD_DCliente.Name = "NUD_DCliente"
-            Me.NUD_DCliente.Size = New System.Drawing.Size(439, 42)
-            Me.NUD_DCliente.TabIndex = 129
-            Me.NUD_DCliente.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
             '
             'BTN_DColocarTotal
             '
@@ -593,7 +529,6 @@
             Me.TXT_DVuelto.Location = New System.Drawing.Point(101, 322)
             Me.TXT_DVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_DVuelto.Name = "TXT_DVuelto"
-            Me.TXT_DVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_DVuelto.PlaceholderText = ""
             Me.TXT_DVuelto.ReadOnly = True
             Me.TXT_DVuelto.SelectedText = ""
@@ -629,7 +564,6 @@
             Me.TXT_DTotal.Location = New System.Drawing.Point(101, 50)
             Me.TXT_DTotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_DTotal.Name = "TXT_DTotal"
-            Me.TXT_DTotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_DTotal.PlaceholderText = ""
             Me.TXT_DTotal.ReadOnly = True
             Me.TXT_DTotal.SelectedText = ""
@@ -652,8 +586,8 @@
             'Mixto
             '
             Me.Mixto.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-            Me.Mixto.Controls.Add(Me.NUD_MTarjeta)
-            Me.Mixto.Controls.Add(Me.NUD_MEfectivo)
+            Me.Mixto.Controls.Add(Me.TXT_MEfectivo)
+            Me.Mixto.Controls.Add(Me.TXT_MTarjeta)
             Me.Mixto.Controls.Add(Me.BTN_RestanteEfectivo)
             Me.Mixto.Controls.Add(Me.BTN_RestanteTarjeta)
             Me.Mixto.Controls.Add(Me.Guna2HtmlLabel16)
@@ -668,32 +602,6 @@
             Me.Mixto.Size = New System.Drawing.Size(641, 381)
             Me.Mixto.TabIndex = 4
             Me.Mixto.Text = "Mixto"
-            '
-            'NUD_MTarjeta
-            '
-            Me.NUD_MTarjeta.BackColor = System.Drawing.Color.Transparent
-            Me.NUD_MTarjeta.BorderRadius = 10
-            Me.NUD_MTarjeta.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.NUD_MTarjeta.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-            Me.NUD_MTarjeta.Location = New System.Drawing.Point(15, 146)
-            Me.NUD_MTarjeta.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-            Me.NUD_MTarjeta.Name = "NUD_MTarjeta"
-            Me.NUD_MTarjeta.Size = New System.Drawing.Size(300, 42)
-            Me.NUD_MTarjeta.TabIndex = 136
-            Me.NUD_MTarjeta.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-            '
-            'NUD_MEfectivo
-            '
-            Me.NUD_MEfectivo.BackColor = System.Drawing.Color.Transparent
-            Me.NUD_MEfectivo.BorderRadius = 10
-            Me.NUD_MEfectivo.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.NUD_MEfectivo.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-            Me.NUD_MEfectivo.Location = New System.Drawing.Point(329, 146)
-            Me.NUD_MEfectivo.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-            Me.NUD_MEfectivo.Name = "NUD_MEfectivo"
-            Me.NUD_MEfectivo.Size = New System.Drawing.Size(300, 42)
-            Me.NUD_MEfectivo.TabIndex = 135
-            Me.NUD_MEfectivo.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
             '
             'BTN_RestanteEfectivo
             '
@@ -753,7 +661,6 @@
             Me.TXT_MVuelto.Location = New System.Drawing.Point(109, 311)
             Me.TXT_MVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_MVuelto.Name = "TXT_MVuelto"
-            Me.TXT_MVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_MVuelto.PlaceholderText = ""
             Me.TXT_MVuelto.ReadOnly = True
             Me.TXT_MVuelto.SelectedText = ""
@@ -801,7 +708,6 @@
             Me.TXT_MTotal.Location = New System.Drawing.Point(109, 42)
             Me.TXT_MTotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_MTotal.Name = "TXT_MTotal"
-            Me.TXT_MTotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_MTotal.PlaceholderText = ""
             Me.TXT_MTotal.ReadOnly = True
             Me.TXT_MTotal.SelectedText = ""
@@ -889,7 +795,6 @@
             Me.TXT_Comentario.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
             Me.TXT_Comentario.Multiline = True
             Me.TXT_Comentario.Name = "TXT_Comentario"
-            Me.TXT_Comentario.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
             Me.TXT_Comentario.PlaceholderText = ""
             Me.TXT_Comentario.SelectedText = ""
             Me.TXT_Comentario.Size = New System.Drawing.Size(745, 86)
@@ -926,6 +831,138 @@
             Me.Guna2Panel1.Size = New System.Drawing.Size(908, 69)
             Me.Guna2Panel1.TabIndex = 131
             '
+            'TXT_ECliente
+            '
+            Me.TXT_ECliente.BorderRadius = 10
+            Me.TXT_ECliente.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_ECliente.DefaultText = "0"
+            Me.TXT_ECliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_ECliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_ECliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_ECliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_ECliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_ECliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_ECliente.ForeColor = System.Drawing.Color.Black
+            Me.TXT_ECliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_ECliente.Location = New System.Drawing.Point(103, 144)
+            Me.TXT_ECliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_ECliente.Name = "TXT_ECliente"
+            Me.TXT_ECliente.PlaceholderText = ""
+            Me.TXT_ECliente.SelectedText = ""
+            Me.TXT_ECliente.Size = New System.Drawing.Size(439, 42)
+            Me.TXT_ECliente.TabIndex = 109
+            Me.TXT_ECliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
+            'TXT_TCliente
+            '
+            Me.TXT_TCliente.BorderRadius = 10
+            Me.TXT_TCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_TCliente.DefaultText = "0"
+            Me.TXT_TCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_TCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_TCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_TCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_TCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_TCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_TCliente.ForeColor = System.Drawing.Color.Black
+            Me.TXT_TCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_TCliente.Location = New System.Drawing.Point(101, 156)
+            Me.TXT_TCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_TCliente.Name = "TXT_TCliente"
+            Me.TXT_TCliente.PlaceholderText = ""
+            Me.TXT_TCliente.SelectedText = ""
+            Me.TXT_TCliente.Size = New System.Drawing.Size(439, 42)
+            Me.TXT_TCliente.TabIndex = 114
+            Me.TXT_TCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
+            'TXT_SCliente
+            '
+            Me.TXT_SCliente.BorderRadius = 10
+            Me.TXT_SCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_SCliente.DefaultText = "0"
+            Me.TXT_SCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_SCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_SCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_SCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_SCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_SCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_SCliente.ForeColor = System.Drawing.Color.Black
+            Me.TXT_SCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_SCliente.Location = New System.Drawing.Point(101, 150)
+            Me.TXT_SCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_SCliente.Name = "TXT_SCliente"
+            Me.TXT_SCliente.PlaceholderText = ""
+            Me.TXT_SCliente.SelectedText = ""
+            Me.TXT_SCliente.Size = New System.Drawing.Size(439, 42)
+            Me.TXT_SCliente.TabIndex = 120
+            Me.TXT_SCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
+            'TXT_DCliente
+            '
+            Me.TXT_DCliente.BorderRadius = 10
+            Me.TXT_DCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_DCliente.DefaultText = "0"
+            Me.TXT_DCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_DCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_DCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_DCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_DCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_DCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_DCliente.ForeColor = System.Drawing.Color.Black
+            Me.TXT_DCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_DCliente.Location = New System.Drawing.Point(101, 148)
+            Me.TXT_DCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_DCliente.Name = "TXT_DCliente"
+            Me.TXT_DCliente.PlaceholderText = ""
+            Me.TXT_DCliente.SelectedText = ""
+            Me.TXT_DCliente.Size = New System.Drawing.Size(439, 42)
+            Me.TXT_DCliente.TabIndex = 129
+            Me.TXT_DCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
+            'TXT_MTarjeta
+            '
+            Me.TXT_MTarjeta.BorderRadius = 10
+            Me.TXT_MTarjeta.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_MTarjeta.DefaultText = "0"
+            Me.TXT_MTarjeta.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_MTarjeta.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_MTarjeta.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_MTarjeta.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_MTarjeta.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_MTarjeta.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_MTarjeta.ForeColor = System.Drawing.Color.Black
+            Me.TXT_MTarjeta.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_MTarjeta.Location = New System.Drawing.Point(15, 146)
+            Me.TXT_MTarjeta.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_MTarjeta.Name = "TXT_MTarjeta"
+            Me.TXT_MTarjeta.PlaceholderText = ""
+            Me.TXT_MTarjeta.SelectedText = ""
+            Me.TXT_MTarjeta.Size = New System.Drawing.Size(300, 42)
+            Me.TXT_MTarjeta.TabIndex = 136
+            Me.TXT_MTarjeta.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
+            'TXT_MEfectivo
+            '
+            Me.TXT_MEfectivo.BorderRadius = 10
+            Me.TXT_MEfectivo.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_MEfectivo.DefaultText = "0"
+            Me.TXT_MEfectivo.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_MEfectivo.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_MEfectivo.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_MEfectivo.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_MEfectivo.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_MEfectivo.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_MEfectivo.ForeColor = System.Drawing.Color.Black
+            Me.TXT_MEfectivo.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_MEfectivo.Location = New System.Drawing.Point(329, 146)
+            Me.TXT_MEfectivo.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_MEfectivo.Name = "TXT_MEfectivo"
+            Me.TXT_MEfectivo.PlaceholderText = ""
+            Me.TXT_MEfectivo.SelectedText = ""
+            Me.TXT_MEfectivo.Size = New System.Drawing.Size(300, 42)
+            Me.TXT_MEfectivo.TabIndex = 137
+            Me.TXT_MEfectivo.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
             'P_TerminarVenta
             '
             Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -945,20 +982,14 @@
             Me.TabControlTVenta.ResumeLayout(False)
             Me.Efectivo.ResumeLayout(False)
             Me.Efectivo.PerformLayout()
-            CType(Me.NUD_ECliente, System.ComponentModel.ISupportInitialize).EndInit()
             Me.Tarjeta.ResumeLayout(False)
             Me.Tarjeta.PerformLayout()
-            CType(Me.NUD_TCliente, System.ComponentModel.ISupportInitialize).EndInit()
             Me.Sinpe.ResumeLayout(False)
             Me.Sinpe.PerformLayout()
-            CType(Me.NUD_SCliente, System.ComponentModel.ISupportInitialize).EndInit()
             Me.deposito.ResumeLayout(False)
             Me.deposito.PerformLayout()
-            CType(Me.NUD_DCliente, System.ComponentModel.ISupportInitialize).EndInit()
             Me.Mixto.ResumeLayout(False)
             Me.Mixto.PerformLayout()
-            CType(Me.NUD_MTarjeta, System.ComponentModel.ISupportInitialize).EndInit()
-            CType(Me.NUD_MEfectivo, System.ComponentModel.ISupportInitialize).EndInit()
             Me.Guna2Panel1.ResumeLayout(False)
             Me.ResumeLayout(False)
             Me.PerformLayout()
@@ -1010,12 +1041,12 @@
         Friend WithEvents BTN_DColocarTotal As Guna.UI2.WinForms.Guna2TileButton
         Friend WithEvents BTN_RestanteEfectivo As Guna.UI2.WinForms.Guna2TileButton
         Friend WithEvents BTN_RestanteTarjeta As Guna.UI2.WinForms.Guna2TileButton
-        Friend WithEvents NUD_ECliente As Guna.UI2.WinForms.Guna2NumericUpDown
-        Friend WithEvents NUD_TCliente As Guna.UI2.WinForms.Guna2NumericUpDown
-        Friend WithEvents NUD_SCliente As Guna.UI2.WinForms.Guna2NumericUpDown
-        Friend WithEvents NUD_DCliente As Guna.UI2.WinForms.Guna2NumericUpDown
-        Friend WithEvents NUD_MTarjeta As Guna.UI2.WinForms.Guna2NumericUpDown
-        Friend WithEvents NUD_MEfectivo As Guna.UI2.WinForms.Guna2NumericUpDown
+        Friend WithEvents TXT_ECliente As Guna.UI2.WinForms.Guna2TextBox
+        Friend WithEvents TXT_TCliente As Guna.UI2.WinForms.Guna2TextBox
+        Friend WithEvents TXT_SCliente As Guna.UI2.WinForms.Guna2TextBox
+        Friend WithEvents TXT_DCliente As Guna.UI2.WinForms.Guna2TextBox
+        Friend WithEvents TXT_MTarjeta As Guna.UI2.WinForms.Guna2TextBox
+        Friend WithEvents TXT_MEfectivo As Guna.UI2.WinForms.Guna2TextBox
     End Class
 
 End Namespace

--- a/SistemaFacturación/Forms/Caja/P_TerminarVenta.vb
+++ b/SistemaFacturación/Forms/Caja/P_TerminarVenta.vb
@@ -19,7 +19,7 @@ Namespace SistemaFacturacion.Forms.Caja
 
         Private btnTotalesList As List(Of Guna2TileButton)
         Private btnRestanteList As List(Of Guna2TileButton)
-        Private nudcalcVuelto As List(Of Guna2NumericUpDown)
+        Private txtEntregaCliente As List(Of Guna2TextBox)
         Private txtShowTotal As List(Of Guna2TextBox)
 
         ' Manejador del evento Load del formulario
@@ -33,13 +33,13 @@ Namespace SistemaFacturacion.Forms.Caja
             }
             btnRestanteList = New List(Of Guna2TileButton) From {BTN_RestanteEfectivo, BTN_RestanteTarjeta}
 
-            nudcalcVuelto = New List(Of Guna2NumericUpDown) From {
-                NUD_ECliente,
-                NUD_TCliente,
-                NUD_SCliente,
-                NUD_DCliente,
-                NUD_MEfectivo,
-                NUD_MTarjeta
+            txtEntregaCliente = New List(Of Guna2TextBox) From {
+                TXT_ECliente,
+                TXT_TCliente,
+                TXT_SCliente,
+                TXT_DCliente,
+                TXT_MEfectivo,
+                TXT_MTarjeta
             }
             txtShowTotal = New List(Of Guna2TextBox) From {
                 TXT_ETotal,
@@ -49,7 +49,8 @@ Namespace SistemaFacturacion.Forms.Caja
                 TXT_MTotal
             }
             ' Valida el estado inicial del pago y habilita/deshabilita los botones de venta
-            BTN_TVenta.Enabled = NUD_ECliente.Value > 0
+            Dim entregaCliente As Decimal = If(Integer.TryParse(TXT_ECliente.Text, entregaCliente), entregaCliente, 0)
+            BTN_TVenta.Enabled = entregaCliente > venta.Saldo_total
         End Sub
         Private Sub P_TerminarVenta_Shown(sender As Object, e As EventArgs) Handles MyBase.Shown
             ' Añade los manejadores de eventos (handlers) para los botones de "Colocar Total"
@@ -65,8 +66,9 @@ Namespace SistemaFacturacion.Forms.Caja
 
             ' Añade los manejadores de eventos para los cambios en los TextBox de pago
             ' Esto asegura que el cálculo del vuelto y la validación se actualicen automáticamente
-            For Each txt As Guna2NumericUpDown In nudcalcVuelto
-                AddHandler txt.ValueChanged, AddressOf RecalcularVueltoYValidar
+            For Each txt As Guna2TextBox In txtEntregaCliente
+                AddHandler txt.TextChanged, AddressOf RecalcularVueltoYValidar
+                AddHandler txt.KeyPress, AddressOf verifyNumericOnKeyPress
             Next
 
             Dim saldo = If(isCuentaPorCobrar, venta.Saldo_restante, venta.Saldo_total)
@@ -87,74 +89,119 @@ Namespace SistemaFacturacion.Forms.Caja
             End If
         End Sub
 
+        ' Manjeador de evento unificado para la verificación de los montos ingresados
+        Private Sub verifyNumericOnKeyPress(sender As Object, e As KeyPressEventArgs)
+            ' 1. Permitir el uso de teclas de control (como Backspace)
+            If Char.IsControl(e.KeyChar) Then
+                e.Handled = False
+                Exit Sub
+            End If
+
+            ' Obtener el separador decimal de la configuración regional (',' o '.')
+            Dim separadorDecimal As Char = Convert.ToChar(System.Globalization.CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator)
+
+            ' 2. Bloquear cualquier cosa que NO sea un dígito y NO sea el separador decimal.
+            If Not Char.IsDigit(e.KeyChar) AndAlso e.KeyChar <> separadorDecimal Then
+                e.Handled = True ' Bloquear la entrada del carácter
+
+                ' 3. Si es el separador decimal, verificar si ya existe uno en la caja de texto.
+            ElseIf e.KeyChar = separadorDecimal Then
+                Dim txtBox As TextBox = DirectCast(sender, TextBox)
+
+                If txtBox.Text.Contains(separadorDecimal) Then
+                    e.Handled = True ' Bloquear si ya existe un separador (solo se permite uno)
+                Else
+                    e.Handled = False ' Permitir el separador
+                End If
+            End If
+        End Sub
+
         ' Manejador de evento unificado para los cambios en los TextBox de pago
         Private Sub RecalcularVueltoYValidar(sender As Object, e As EventArgs)
             ' Convierte el objeto sender al tipo de control Guna2TextBox
-            Dim nud As Guna2NumericUpDown = CType(sender, Guna2NumericUpDown)
-
-            Dim entregaCliente As Decimal = nud.Value
-            If nud.Name = "TXT_PagoTarjeta" Or nud.Name = "TXT_PagoEfectivo" Then
-                entregaCliente = NUD_MEfectivo.Value + NUD_MTarjeta.Value
-            End If
+            Dim txt As Guna2TextBox = CType(sender, Guna2TextBox)
+            Dim entregaCliente As Decimal
             Dim txtVuelto As Guna2TextBox
 
-            Select Case nud.Name
-                Case "NUD_ECliente"
-                    entregaCliente = nud.Value
-                    txtVuelto = TXT_EVuelto
-                Case "NUD_TCliente"
-                    entregaCliente = nud.Value
-                    txtVuelto = TXT_TVuelto
-                Case "NUD_SCliente"
-                    entregaCliente = nud.Value
-                    txtVuelto = TXT_SVuelto
-                Case "NUD_DCliente"
-                    entregaCliente = nud.Value
-                    txtVuelto = TXT_DVuelto
-                Case Else
-                    entregaCliente = NUD_MEfectivo.Value + NUD_MTarjeta.Value
-                    txtVuelto = TXT_MVuelto
-            End Select
+            Try
+                Select Case txt.Name
+                    Case "TXT_ECliente"
+                        txtVuelto = TXT_EVuelto
+                    Case "TXT_TCliente"
+                        txtVuelto = TXT_TVuelto
+                    Case "TXT_SCliente"
+                        txtVuelto = TXT_SVuelto
+                    Case "TXT_DCliente"
+                        txtVuelto = TXT_DVuelto
+                    Case Else
+                        txtVuelto = TXT_MVuelto
+                End Select
+                If Not Decimal.TryParse(If(String.IsNullOrEmpty(txt.Text), 0, txt.Text), entregaCliente) Then
+                    MsgError($"El monto ingresado no es válido. No se puede pasar a Decimal el monto: {txt.Text}")
+                    Exit Sub
+                End If
+                Dim efectivo As Decimal
+                Dim tarjeta As Decimal
+                If txt.Name = "TXT_MEfectivo" Or txt.Name = "TXT_MTarjeta" Then
+                    If Not Decimal.TryParse(TXT_MEfectivo.Text, efectivo) Then
+                        MsgError($"El monto en efectivo ingresado no es válido. No se puede pasar a Decimal el monto: {TXT_MEfectivo.Text}")
+                        Exit Sub
+                    End If
+                    If Not Decimal.TryParse(TXT_MTarjeta.Text, tarjeta) Then
+                        MsgError($"El monto en tarjeta ingresado no es válido. No se puede pasar a Decimal el monto: {TXT_MTarjeta.Text}")
+                        Exit Sub
+                    End If
 
-            BTN_TVenta.Enabled = nud.Value > 0
+                    entregaCliente = efectivo + tarjeta
+                End If
 
-            getVuelto(nud.Value, txtVuelto)
+                BTN_TVenta.Enabled = entregaCliente >= venta.Saldo_total
+
+                GetVuelto(txt.Text, txtVuelto)
+            Catch ex As Exception
+                MsgError("Error al recalcular el vuelto y validar: " & ex.Message)
+                GetVuelto(0, txtVuelto)
+            End Try
         End Sub
         ' Manejador de evento unificado para los botones de "Colocar Total"
         ' "sender" es el botón que ha sido presionado
         Private Sub ColocarTotal(sender As Object, e As EventArgs)
             ' Convierte el objeto sender al tipo de control Guna2Button
             Dim btn As Guna2Button = CType(sender, Guna2Button)
-
+            Dim txtEntregaCliente As Guna2TextBox
             ' Usa un Select Case para identificar qué botón se hizo clic y actualizar el TextBox correcto
             Select Case btn.Name
-                Case "BTN_EColocarTotal"
-                    NUD_ECliente.Value = venta.Saldo_total
                 Case "BTN_TColocarTotal"
-                    NUD_TCliente.Value = venta.Saldo_total
+                    txtEntregaCliente = TXT_TCliente
                 Case "BTN_SColocarTotal"
-                    NUD_SCliente.Value = venta.Saldo_total
+                    txtEntregaCliente = TXT_SCliente
                 Case "BTN_DColocarTotal"
-                    NUD_DCliente.Value = venta.Saldo_total
+                    txtEntregaCliente = TXT_DCliente
+                Case Else
+                    txtEntregaCliente = TXT_ECliente
             End Select
+
+            txtEntregaCliente.Text = venta.Saldo_total
         End Sub
 
         ' Calcula el monto restante para pago mixto
-        Private Sub CargarRestante(efectivo As Boolean)
-            Dim restante As Double
-            If efectivo Then ' Si el botón de efectivo restante fue presionado
-                restante = venta.Saldo_total - NUD_MTarjeta.Value
-                If restante < 0 Then
-                    restante = 0
+        Private Sub CargarRestante(fromEfectivo As Boolean)
+            Dim restante As Decimal
+            Dim dineroColocado As Decimal
+            Dim txtMontoActual As Guna2TextBox = If(Not fromEfectivo, TXT_MEfectivo, TXT_MTarjeta)
+            Dim txtCargarRestante As Guna2TextBox = If(fromEfectivo, TXT_MEfectivo, TXT_MTarjeta)
+
+            Try
+                If Not Decimal.TryParse(txtMontoActual.Text, dineroColocado) Then
+                    Throw New Exception($"El monto ingresado no es válido. No se puede pasar a Decimal el monto: {txtMontoActual.Text}")
                 End If
-                NUD_MEfectivo.Value = restante
-            Else ' Si el botón de tarjeta restante fue presionado
-                restante = venta.Saldo_total - NUD_MEfectivo.Value
-                If restante < 0 Then
-                    restante = 0
-                End If
-                NUD_MTarjeta.Value = restante
-            End If
+
+                restante = venta.Saldo_total - dineroColocado
+            Catch ex As Exception
+                MsgError("Error al calcular el restante: " & ex.Message)
+            End Try
+
+            txtCargarRestante.Text = If(restante < 0, 0, restante)
         End Sub
 
         'Se agrega el restante al campo correspondiente
@@ -168,9 +215,26 @@ Namespace SistemaFacturacion.Forms.Caja
                 Case "BTN_RestanteEfectivo"
                     CargarRestante(True)
             End Select
-            Dim entregaCliente As Decimal = NUD_MEfectivo.Value + NUD_MTarjeta.Value
+
+            Dim efectivo As Decimal
+            Dim tarjeta As Decimal
+            Dim entregaCliente As Decimal
+
+            Try
+                If Not Decimal.TryParse(TXT_MEfectivo.Text, efectivo) Then
+                    Throw New Exception($"El monto en efectivo ingresado no es válido. No se puede pasar a Decimal el monto: {TXT_MEfectivo.Text}")
+                End If
+                If Not Decimal.TryParse(TXT_MTarjeta.Text, tarjeta) Then
+                    Throw New Exception($"El monto en tarjeta ingresado no es válido. No se puede pasar a Decimal el monto: {TXT_MTarjeta.Text}")
+                End If
+                entregaCliente = efectivo + tarjeta
+            Catch ex As Exception
+                MsgError("Error al calcular el monto restante: " & ex.Message)
+                entregaCliente = 0
+            End Try
+
             ' Recalcula el vuelto y valida los montos después de agregar el restante
-            getVuelto(entregaCliente, TXT_MVuelto)
+            GetVuelto(entregaCliente, TXT_MVuelto)
         End Sub
 #End Region
 
@@ -178,20 +242,48 @@ Namespace SistemaFacturacion.Forms.Caja
 #Region "TerminarVenta_ImprimirFactura"
 
         Private Sub TerminarVenta(imprimir As Boolean)
-            venta.tipo_pago = TabControlTVenta.SelectedIndex
+            venta.Tipo_pago = TabControlTVenta.SelectedIndex
+
             Select Case venta.Tipo_pago
                 Case 0 ' Efectivo
-                    venta.Efectivo = NUD_ECliente.Value
-                Case 1 ' Tarjeta
-                    venta.Tarjeta = NUD_TCliente.Value
-                Case 2 ' Sinpe
-                    venta.Tarjeta = NUD_SCliente.Value
-                Case 3 ' Depósito
-                    venta.Tarjeta = NUD_DCliente.Value
+                    If Not Decimal.TryParse(TXT_ECliente.Text, venta.Efectivo) Then
+                        MsgError("El monto en efectivo no es válido: " & TXT_ECliente.Text)
+                        Exit Sub
+                    End If
+                    venta.Tarjeta = 0
+
+                Case 1, 2, 3 ' Tarjeta, Sinpe, Depósito (Se usa el mismo patrón para el monto de la Tarjeta)
+                    Dim txtControl As Guna2TextBox = TXT_TCliente
+                    Select Case venta.Tipo_pago
+                        Case 2 : txtControl = TXT_SCliente
+                        Case 3 : txtControl = TXT_DCliente
+                    End Select
+
+                    If Not Decimal.TryParse(txtControl.Text, venta.Tarjeta) Then
+                        MsgError($"El monto de pago (Tipo {venta.Tipo_pago}) no es válido: {txtControl.Text}")
+                        Exit Sub
+                    End If
+                    venta.Efectivo = 0
+
                 Case 4 ' Mixto
-                    venta.Efectivo = NUD_MEfectivo.Value
-                    venta.Tarjeta = NUD_MTarjeta.Value
+                    ' 1. Validar Efectivo
+                    If Not Decimal.TryParse(TXT_MEfectivo.Text, venta.Efectivo) Then
+                        MsgError("El monto en efectivo para el pago mixto no es válido: " & TXT_MEfectivo.Text)
+                        Exit Sub
+                    End If
+
+                    ' 2. Validar Tarjeta
+                    If Not Decimal.TryParse(TXT_MTarjeta.Text, venta.Tarjeta) Then
+                        MsgError("El monto de tarjeta para el pago mixto no es válido: " & TXT_MTarjeta.Text)
+                        Exit Sub
+                    End If
+
+                Case Else
+                    ' Manejar cualquier otro caso, si aplica. Por ejemplo:
+                    MsgError("Tipo de pago no reconocido.")
+                    Exit Sub
             End Select
+
             imprimir_factura = imprimir
             Me.DialogResult = DialogResult.OK
         End Sub

--- a/SistemaFacturación/Forms/Mantenimiento/C_Productos.Designer.vb
+++ b/SistemaFacturación/Forms/Mantenimiento/C_Productos.Designer.vb
@@ -53,9 +53,15 @@
             Me.SWT_Recientes = New Guna.UI2.WinForms.Guna2ToggleSwitch()
             Me.BTN_Config = New Guna.UI2.WinForms.Guna2ImageButton()
             Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel()
+            Me.GBX_Filter = New Guna.UI2.WinForms.Guna2GroupBox()
+            Me.RDB_All = New Guna.UI2.WinForms.Guna2RadioButton()
+            Me.RDB_200 = New Guna.UI2.WinForms.Guna2RadioButton()
+            Me.RDB_100 = New Guna.UI2.WinForms.Guna2RadioButton()
+            Me.RDB_500 = New Guna.UI2.WinForms.Guna2RadioButton()
             Me.MNU_CONTX.SuspendLayout()
             CType(Me.DGV_Prods, System.ComponentModel.ISupportInitialize).BeginInit()
             Me.TableLayoutPanel1.SuspendLayout()
+            Me.GBX_Filter.SuspendLayout()
             Me.SuspendLayout()
             '
             'BTN_NProd
@@ -180,7 +186,7 @@
             Me.Label2.AutoSize = True
             Me.Label2.Font = New System.Drawing.Font("Britannic Bold", 15.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label2.ForeColor = System.Drawing.Color.White
-            Me.Label2.Location = New System.Drawing.Point(395, 88)
+            Me.Label2.Location = New System.Drawing.Point(295, 88)
             Me.Label2.Name = "Label2"
             Me.Label2.Size = New System.Drawing.Size(109, 23)
             Me.Label2.TabIndex = 59
@@ -191,7 +197,7 @@
             Me.Label3.AutoSize = True
             Me.Label3.Font = New System.Drawing.Font("Britannic Bold", 15.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label3.ForeColor = System.Drawing.Color.White
-            Me.Label3.Location = New System.Drawing.Point(809, 88)
+            Me.Label3.Location = New System.Drawing.Point(620, 88)
             Me.Label3.Name = "Label3"
             Me.Label3.Size = New System.Drawing.Size(105, 23)
             Me.Label3.TabIndex = 61
@@ -214,7 +220,7 @@
             Me.TXT_BuscarMarca.Name = "TXT_BuscarMarca"
             Me.TXT_BuscarMarca.PlaceholderText = "Doble click para buscar"
             Me.TXT_BuscarMarca.SelectedText = ""
-            Me.TXT_BuscarMarca.Size = New System.Drawing.Size(256, 42)
+            Me.TXT_BuscarMarca.Size = New System.Drawing.Size(162, 42)
             Me.TXT_BuscarMarca.TabIndex = 65
             '
             'TXT_BuscarProv
@@ -230,11 +236,11 @@
             Me.TXT_BuscarProv.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.TXT_BuscarProv.ForeColor = System.Drawing.Color.Black
             Me.TXT_BuscarProv.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_BuscarProv.Location = New System.Drawing.Point(510, 80)
+            Me.TXT_BuscarProv.Location = New System.Drawing.Point(410, 80)
             Me.TXT_BuscarProv.Name = "TXT_BuscarProv"
             Me.TXT_BuscarProv.PlaceholderText = "Doble click para buscar"
             Me.TXT_BuscarProv.SelectedText = ""
-            Me.TXT_BuscarProv.Size = New System.Drawing.Size(256, 42)
+            Me.TXT_BuscarProv.Size = New System.Drawing.Size(155, 42)
             Me.TXT_BuscarProv.TabIndex = 66
             '
             'TXT_BuscarCat
@@ -250,11 +256,11 @@
             Me.TXT_BuscarCat.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.TXT_BuscarCat.ForeColor = System.Drawing.Color.Black
             Me.TXT_BuscarCat.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_BuscarCat.Location = New System.Drawing.Point(916, 80)
+            Me.TXT_BuscarCat.Location = New System.Drawing.Point(727, 80)
             Me.TXT_BuscarCat.Name = "TXT_BuscarCat"
             Me.TXT_BuscarCat.PlaceholderText = "Doble click para buscar"
             Me.TXT_BuscarCat.SelectedText = ""
-            Me.TXT_BuscarCat.Size = New System.Drawing.Size(256, 42)
+            Me.TXT_BuscarCat.Size = New System.Drawing.Size(166, 42)
             Me.TXT_BuscarCat.TabIndex = 67
             '
             'DGV_Prods
@@ -355,7 +361,7 @@
             Me.Label5.AutoSize = True
             Me.Label5.Font = New System.Drawing.Font("Britannic Bold", 11.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label5.ForeColor = System.Drawing.Color.White
-            Me.Label5.Location = New System.Drawing.Point(83, 131)
+            Me.Label5.Location = New System.Drawing.Point(14, 131)
             Me.Label5.Name = "Label5"
             Me.Label5.Size = New System.Drawing.Size(191, 16)
             Me.Label5.TabIndex = 71
@@ -368,7 +374,7 @@
             Me.SWT_Marca.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
             Me.SWT_Marca.CheckedState.InnerBorderColor = System.Drawing.Color.White
             Me.SWT_Marca.CheckedState.InnerColor = System.Drawing.Color.White
-            Me.SWT_Marca.Location = New System.Drawing.Point(280, 127)
+            Me.SWT_Marca.Location = New System.Drawing.Point(211, 127)
             Me.SWT_Marca.Name = "SWT_Marca"
             Me.SWT_Marca.Size = New System.Drawing.Size(37, 20)
             Me.SWT_Marca.TabIndex = 70
@@ -382,7 +388,7 @@
             Me.Label4.AutoSize = True
             Me.Label4.Font = New System.Drawing.Font("Britannic Bold", 11.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label4.ForeColor = System.Drawing.Color.White
-            Me.Label4.Location = New System.Drawing.Point(507, 131)
+            Me.Label4.Location = New System.Drawing.Point(309, 132)
             Me.Label4.Name = "Label4"
             Me.Label4.Size = New System.Drawing.Size(215, 16)
             Me.Label4.TabIndex = 73
@@ -395,7 +401,7 @@
             Me.SWT_Prov.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
             Me.SWT_Prov.CheckedState.InnerBorderColor = System.Drawing.Color.White
             Me.SWT_Prov.CheckedState.InnerColor = System.Drawing.Color.White
-            Me.SWT_Prov.Location = New System.Drawing.Point(728, 127)
+            Me.SWT_Prov.Location = New System.Drawing.Point(530, 128)
             Me.SWT_Prov.Name = "SWT_Prov"
             Me.SWT_Prov.Size = New System.Drawing.Size(35, 20)
             Me.SWT_Prov.TabIndex = 72
@@ -409,7 +415,7 @@
             Me.Label6.AutoSize = True
             Me.Label6.Font = New System.Drawing.Font("Britannic Bold", 11.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label6.ForeColor = System.Drawing.Color.White
-            Me.Label6.Location = New System.Drawing.Point(913, 131)
+            Me.Label6.Location = New System.Drawing.Point(640, 132)
             Me.Label6.Name = "Label6"
             Me.Label6.Size = New System.Drawing.Size(212, 16)
             Me.Label6.TabIndex = 75
@@ -422,7 +428,7 @@
             Me.SWT_Cat.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
             Me.SWT_Cat.CheckedState.InnerBorderColor = System.Drawing.Color.White
             Me.SWT_Cat.CheckedState.InnerColor = System.Drawing.Color.White
-            Me.SWT_Cat.Location = New System.Drawing.Point(1131, 127)
+            Me.SWT_Cat.Location = New System.Drawing.Point(858, 128)
             Me.SWT_Cat.Name = "SWT_Cat"
             Me.SWT_Cat.Size = New System.Drawing.Size(35, 20)
             Me.SWT_Cat.TabIndex = 74
@@ -433,27 +439,25 @@
             '
             'Label7
             '
-            Me.Label7.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
             Me.Label7.AutoSize = True
             Me.Label7.Font = New System.Drawing.Font("Britannic Bold", 11.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Label7.ForeColor = System.Drawing.Color.White
-            Me.Label7.Location = New System.Drawing.Point(1192, 92)
+            Me.Label7.Location = New System.Drawing.Point(936, 92)
             Me.Label7.Name = "Label7"
-            Me.Label7.Size = New System.Drawing.Size(68, 16)
+            Me.Label7.Size = New System.Drawing.Size(90, 16)
             Me.Label7.TabIndex = 122
-            Me.Label7.Text = "Recientes"
+            Me.Label7.Text = "Ver recientes"
             Me.Label7.TextAlign = System.Drawing.ContentAlignment.TopCenter
             '
             'SWT_Recientes
             '
-            Me.SWT_Recientes.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
             Me.SWT_Recientes.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
             Me.SWT_Recientes.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
             Me.SWT_Recientes.CheckedState.InnerBorderColor = System.Drawing.Color.White
             Me.SWT_Recientes.CheckedState.InnerColor = System.Drawing.Color.White
-            Me.SWT_Recientes.Location = New System.Drawing.Point(1198, 111)
+            Me.SWT_Recientes.Location = New System.Drawing.Point(939, 111)
             Me.SWT_Recientes.Name = "SWT_Recientes"
-            Me.SWT_Recientes.Size = New System.Drawing.Size(58, 25)
+            Me.SWT_Recientes.Size = New System.Drawing.Size(87, 31)
             Me.SWT_Recientes.TabIndex = 121
             Me.SWT_Recientes.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
             Me.SWT_Recientes.UncheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
@@ -496,6 +500,109 @@
             Me.TableLayoutPanel1.Size = New System.Drawing.Size(1253, 58)
             Me.TableLayoutPanel1.TabIndex = 126
             '
+            'GBX_Filter
+            '
+            Me.GBX_Filter.BorderColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+            Me.GBX_Filter.BorderRadius = 10
+            Me.GBX_Filter.Controls.Add(Me.RDB_All)
+            Me.GBX_Filter.Controls.Add(Me.RDB_200)
+            Me.GBX_Filter.Controls.Add(Me.RDB_100)
+            Me.GBX_Filter.Controls.Add(Me.RDB_500)
+            Me.GBX_Filter.CustomBorderColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+            Me.GBX_Filter.CustomBorderThickness = New System.Windows.Forms.Padding(0, 20, 0, 0)
+            Me.GBX_Filter.FillColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
+            Me.GBX_Filter.Font = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.GBX_Filter.ForeColor = System.Drawing.Color.White
+            Me.GBX_Filter.Location = New System.Drawing.Point(1068, 80)
+            Me.GBX_Filter.Name = "GBX_Filter"
+            Me.GBX_Filter.Size = New System.Drawing.Size(199, 74)
+            Me.GBX_Filter.TabIndex = 127
+            Me.GBX_Filter.Text = "Filtro"
+            Me.GBX_Filter.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            Me.GBX_Filter.TextOffset = New System.Drawing.Point(0, -10)
+            '
+            'RDB_All
+            '
+            Me.RDB_All.AutoSize = True
+            Me.RDB_All.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_All.CheckedState.BorderThickness = 0
+            Me.RDB_All.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_All.CheckedState.InnerColor = System.Drawing.Color.White
+            Me.RDB_All.CheckedState.InnerOffset = -4
+            Me.RDB_All.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+            Me.RDB_All.ForeColor = System.Drawing.SystemColors.Control
+            Me.RDB_All.Location = New System.Drawing.Point(101, 45)
+            Me.RDB_All.Name = "RDB_All"
+            Me.RDB_All.Size = New System.Drawing.Size(55, 17)
+            Me.RDB_All.TabIndex = 90
+            Me.RDB_All.Text = "Todos"
+            Me.RDB_All.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
+            Me.RDB_All.UncheckedState.BorderThickness = 2
+            Me.RDB_All.UncheckedState.FillColor = System.Drawing.Color.Transparent
+            Me.RDB_All.UncheckedState.InnerColor = System.Drawing.Color.Transparent
+            '
+            'RDB_200
+            '
+            Me.RDB_200.AutoSize = True
+            Me.RDB_200.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_200.CheckedState.BorderThickness = 0
+            Me.RDB_200.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_200.CheckedState.InnerColor = System.Drawing.Color.White
+            Me.RDB_200.CheckedState.InnerOffset = -4
+            Me.RDB_200.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+            Me.RDB_200.ForeColor = System.Drawing.SystemColors.Control
+            Me.RDB_200.Location = New System.Drawing.Point(101, 25)
+            Me.RDB_200.Name = "RDB_200"
+            Me.RDB_200.Size = New System.Drawing.Size(94, 17)
+            Me.RDB_200.TabIndex = 89
+            Me.RDB_200.Text = "200 Productos"
+            Me.RDB_200.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
+            Me.RDB_200.UncheckedState.BorderThickness = 2
+            Me.RDB_200.UncheckedState.FillColor = System.Drawing.Color.Transparent
+            Me.RDB_200.UncheckedState.InnerColor = System.Drawing.Color.Transparent
+            '
+            'RDB_100
+            '
+            Me.RDB_100.AutoSize = True
+            Me.RDB_100.Checked = True
+            Me.RDB_100.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_100.CheckedState.BorderThickness = 0
+            Me.RDB_100.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_100.CheckedState.InnerColor = System.Drawing.Color.White
+            Me.RDB_100.CheckedState.InnerOffset = -4
+            Me.RDB_100.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+            Me.RDB_100.ForeColor = System.Drawing.SystemColors.Control
+            Me.RDB_100.Location = New System.Drawing.Point(7, 25)
+            Me.RDB_100.Name = "RDB_100"
+            Me.RDB_100.Size = New System.Drawing.Size(94, 17)
+            Me.RDB_100.TabIndex = 88
+            Me.RDB_100.TabStop = True
+            Me.RDB_100.Text = "100 Productos"
+            Me.RDB_100.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
+            Me.RDB_100.UncheckedState.BorderThickness = 2
+            Me.RDB_100.UncheckedState.FillColor = System.Drawing.Color.Transparent
+            Me.RDB_100.UncheckedState.InnerColor = System.Drawing.Color.Transparent
+            '
+            'RDB_500
+            '
+            Me.RDB_500.AutoSize = True
+            Me.RDB_500.CheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_500.CheckedState.BorderThickness = 0
+            Me.RDB_500.CheckedState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.RDB_500.CheckedState.InnerColor = System.Drawing.Color.White
+            Me.RDB_500.CheckedState.InnerOffset = -4
+            Me.RDB_500.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+            Me.RDB_500.ForeColor = System.Drawing.SystemColors.Control
+            Me.RDB_500.Location = New System.Drawing.Point(7, 45)
+            Me.RDB_500.Name = "RDB_500"
+            Me.RDB_500.Size = New System.Drawing.Size(94, 17)
+            Me.RDB_500.TabIndex = 87
+            Me.RDB_500.Text = "500 Productos"
+            Me.RDB_500.UncheckedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(125, Byte), Integer), CType(CType(137, Byte), Integer), CType(CType(149, Byte), Integer))
+            Me.RDB_500.UncheckedState.BorderThickness = 2
+            Me.RDB_500.UncheckedState.FillColor = System.Drawing.Color.Transparent
+            Me.RDB_500.UncheckedState.InnerColor = System.Drawing.Color.Transparent
+            '
             'C_Productos
             '
             Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -503,6 +610,7 @@
             Me.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
             Me.CancelButton = Me.BTN_RegresarProd
             Me.ClientSize = New System.Drawing.Size(1280, 637)
+            Me.Controls.Add(Me.GBX_Filter)
             Me.Controls.Add(Me.TableLayoutPanel1)
             Me.Controls.Add(Me.BTN_Config)
             Me.Controls.Add(Me.Label7)
@@ -530,6 +638,8 @@
             Me.MNU_CONTX.ResumeLayout(False)
             CType(Me.DGV_Prods, System.ComponentModel.ISupportInitialize).EndInit()
             Me.TableLayoutPanel1.ResumeLayout(False)
+            Me.GBX_Filter.ResumeLayout(False)
+            Me.GBX_Filter.PerformLayout()
             Me.ResumeLayout(False)
             Me.PerformLayout()
 
@@ -559,5 +669,10 @@
         Friend WithEvents SWT_Recientes As Guna.UI2.WinForms.Guna2ToggleSwitch
         Friend WithEvents BTN_Config As Guna.UI2.WinForms.Guna2ImageButton
         Friend WithEvents TableLayoutPanel1 As TableLayoutPanel
+        Friend WithEvents GBX_Filter As Guna.UI2.WinForms.Guna2GroupBox
+        Friend WithEvents RDB_All As Guna.UI2.WinForms.Guna2RadioButton
+        Friend WithEvents RDB_200 As Guna.UI2.WinForms.Guna2RadioButton
+        Friend WithEvents RDB_100 As Guna.UI2.WinForms.Guna2RadioButton
+        Friend WithEvents RDB_500 As Guna.UI2.WinForms.Guna2RadioButton
     End Class
 End Namespace

--- a/SistemaFacturación/Forms/Mantenimiento/C_Productos.vb
+++ b/SistemaFacturación/Forms/Mantenimiento/C_Productos.vb
@@ -95,8 +95,18 @@ Namespace SistemaFacturacion.Forms.Mantenimiento
                                                                      paramList.Add(New SQLiteParameter("@proveedor", "%" & TXT_BuscarProv.Text & "%"))
                                                                  End If
 
-                                                                 Dim orden As String = If(SWT_Recientes.Checked, " ORDER BY p.fechaAdd DESC;", " ORDER BY p.codigo ASC;")
-                                                                 Dim consultaFinal As String = stringConsultaBase.ToString() & condiciones.ToString() & orden
+                                                                 Dim orden As String = If(SWT_Recientes.Checked, " ORDER BY p.fechaAdd DESC", " ORDER BY p.codigo ASC")
+
+                                                                 Dim limit As String = ""
+                                                                 If RDB_100.Checked Then
+                                                                     limit = " LIMIT 100;"
+                                                                 ElseIf RDB_200.Checked Then
+                                                                     limit = " LIMIT 200;"
+                                                                 ElseIf RDB_500.Checked Then
+                                                                     limit = " LIMIT 500;"
+                                                                 End If
+
+                                                                 Dim consultaFinal As String = stringConsultaBase.ToString() & condiciones.ToString() & orden & limit
 
                                                                  ' Llamada al método para cargar la tabla de forma segura
                                                                  CargarTablaParam(T, consultaFinal, paramList)
@@ -393,6 +403,22 @@ Namespace SistemaFacturacion.Forms.Mantenimiento
 
         Private Sub C_Productos_FormClosing(sender As Object, e As FormClosingEventArgs) Handles MyBase.FormClosing
             ManejarCierreONavegacion(e)
+        End Sub
+
+        Private Sub RDB_100_CheckedChanged(sender As Object, e As EventArgs) Handles RDB_100.CheckedChanged
+            REFRESCAR()
+        End Sub
+
+        Private Sub RDB_200_CheckedChanged(sender As Object, e As EventArgs) Handles RDB_200.CheckedChanged
+            REFRESCAR()
+        End Sub
+
+        Private Sub RDB_500_CheckedChanged(sender As Object, e As EventArgs) Handles RDB_500.CheckedChanged
+            REFRESCAR()
+        End Sub
+
+        Private Sub RDB_All_CheckedChanged(sender As Object, e As EventArgs) Handles RDB_All.CheckedChanged
+            REFRESCAR()
         End Sub
     End Class
 End Namespace

--- a/SistemaFacturación/Modules/Md_IMPRIMIR.vb
+++ b/SistemaFacturación/Modules/Md_IMPRIMIR.vb
@@ -268,13 +268,16 @@ Namespace SistemaFacturacion.Modules
                             printDoc.Print()
                         Else
                             Log.Information("Diálogo de impresión cancelado por el usuario. Impresión abortada.")
+                            Exit Sub
                         End If
                     End Using
 
                     Log.Debug("Mostrando previsualización de impresión.")
                     'Se muestra al usuario una vista previa del proceso de impresión
+#If DEBUG Then
                     Dim printPreview As New PrintPreviewDialog With {.Document = printDoc}
                     printPreview.ShowDialog()
+#End If
                 Catch ex As Exception
                     ' Notificar al usuario (puede que sea necesario)
                     MsgError($"Error fatal al imprimir. Verifique la conexión de la impresora. Error: {ex.Message}")

--- a/SistemaFacturación/My Project/AssemblyInfo.vb
+++ b/SistemaFacturación/My Project/AssemblyInfo.vb
@@ -28,5 +28,5 @@ Imports System.Runtime.InteropServices
 '      Revisión
 '
 
-<Assembly: AssemblyVersion("3.0.2")>
-<Assembly: AssemblyFileVersion("3.0.2")>
+<Assembly: AssemblyVersion("3.0.3")>
+<Assembly: AssemblyFileVersion("3.0.3")>

--- a/SistemaFacturación/SistemaFacturación.vbproj
+++ b/SistemaFacturación/SistemaFacturación.vbproj
@@ -35,7 +35,7 @@
     <WebPage>publish.htm</WebPage>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>3.0.2.0</ApplicationVersion>
+    <ApplicationVersion>3.0.3.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <CreateDesktopShortcut>true</CreateDesktopShortcut>
     <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
# Notas del parche versión 3.0.3 (20 de oct de 2025)

Esta actualización busca resolver algunos problemas identificados anteriormente en varias partes de la aplicación

## Nuevo
Closes #70
- Se agregó un nuevo filtro en la pestaña de consulta de productos, esta ahora ter permite limitar la cantidad de productos que se cargan buscando hacer que estos se carguen de forma más rápido resolviendo el problema de la duración inicial de carga al ingresar a la pestaña de consulta (Este cambio tambipen aplica para la pestaña de busqueda de productos de la caja)

## BugFix

### 1. Terminar venta
Closes #69
- Se revirtió el cambio del la caja de texto numericas a como estaba antes, ahora estas muestran en tiempo real el valor del vuelto sin necesitar de presionar nada y además ya evitan totalmente el ingreso de cualquier tipo de caracter que no sea numérico
- Se mejoró la eficiencia y robustes de los procesos de calculo de vueltos y restantes en la pestaña de terminar venta

### 2. Reimpresión de facturas
Closes #68
- Se arregló un error en el que al presionar el botón de "Reimprimir más reciente" en la pestaña de reimpresiones se mostraba un error y no se podía imprimir
- Se arregló un error relacionado a la selección de la fila con la factura a imprimir en el que a veces al selecionar la primer fila esta no se imprimía correctamente
- Se eliminó el preview que se generaba al terminar la factura ya que en producción no se consideró necesario ya que este se imprimiría en todo caso