### PR TITLE
Fix #78 seleccion automatica del texto en la caja de texto del dinero que entrega el cliente y homogenización de procesos al abonar y terminar ventas

### DIFF
--- a/HISTORICRELREASENOTES.md
+++ b/HISTORICRELREASENOTES.md
@@ -1,3 +1,26 @@
+# Notas del parche versión 3.0.4 (28 de oct de 2025)
+
+Esta actualización busca resolver algunos problemas identificados anteriormente en varias partes de la aplicación, presentando mejoras de vida en la finalización de la venta, en la consulta de productos y más.
+
+# BugFix
+## Abonar o terminar venta
+Closes #78 
+- Se homogenizaron los procesos de las pestañs de terminar venta para que funcionen de la misma forma  los calculos y las acciones
+- Ahora al cambiar de tipo de venta en las pestañas de abonar o terminar venta el texto se selecciona automáticamente para poder cambiarlo sin tener que selecionar el texto completamente de forma manual
+- Ahora al entrar a las pestañas de abonar o terminar venta se coloca automáticamente el monto total de la venta para simplemente presionar el botón de terminar venta o f7 en ese caso
+
+## Movimientos en cierres de caja
+Closes #79
+- Se arregló un error en el que si se agregaba un solo un cierre o una sola salida el sistema se caía al no detectar información del otro movimiento, ahora ya se maneja corretcamente
+
+## Cierre de sesión
+Closes #75
+- Se arregló un error en el que al presionar el botón de cerrar sesión en el menú principal la aplicación se cerraba y no cerraba sesión correctamente
+
+## Mantenimiento de productos
+- Closes #77: Se arregló un error en el que al terminar de guardar un producto nuevo la pestaña no se cerraba correctamente y se mantenía abierta sin la posibilidad de cerrarla de formas normales
+- Closes #76: Ahora al regresar de las pestañas de agregar o modificar los productos se seleccionará de forma automática todo el texto de la caja de texto de busqueda de productos para poder agregar directamente el siguiente
+     
 # Notas del parche versión 3.0.3 (20 de oct de 2025)
 
 Esta actualización busca resolver algunos problemas identificados anteriormente en varias partes de la aplicación

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,26 +1,23 @@
-# Notas del parche versión 3.0.3 (20 de oct de 2025)
+# Notas del parche versión 3.0.4 (28 de oct de 2025)
 
-Esta actualización busca resolver algunos problemas identificados anteriormente en varias partes de la aplicación
+Esta actualización busca resolver algunos problemas identificados anteriormente en varias partes de la aplicación, presentando mejoras de vida en la finalización de la venta, en la consulta de productos y más.
 
-## Nuevo
-Closes #70
-- Se agregó un nuevo filtro en la pestaña de consulta de productos, esta ahora ter permite limitar la cantidad de productos que se cargan buscando hacer que estos se carguen de forma más rápido resolviendo el problema de la duración inicial de carga al ingresar a la pestaña de consulta (Este cambio tambipen aplica para la pestaña de busqueda de productos de la caja)
+# BugFix
+## Abonar o terminar venta
+Closes #78 
+- Se homogenizaron los procesos de las pestañs de terminar venta para que funcionen de la misma forma  los calculos y las acciones
+- Ahora al cambiar de tipo de venta en las pestañas de abonar o terminar venta el texto se selecciona automáticamente para poder cambiarlo sin tener que selecionar el texto completamente de forma manual
+- Ahora al entrar a las pestañas de abonar o terminar venta se coloca automáticamente el monto total de la venta para simplemente presionar el botón de terminar venta o f7 en ese caso
 
-## BugFix
+## Movimientos en cierres de caja
+Closes #79
+- Se arregló un error en el que si se agregaba un solo un cierre o una sola salida el sistema se caía al no detectar información del otro movimiento, ahora ya se maneja corretcamente
 
-### 1. Terminar venta
-Closes #69
-- Se revirtió el cambio del la caja de texto numericas a como estaba antes, ahora estas muestran en tiempo real el valor del vuelto sin necesitar de presionar nada y además ya evitan totalmente el ingreso de cualquier tipo de caracter que no sea numérico
-- Se mejoró la eficiencia y robustes de los procesos de calculo de vueltos y restantes en la pestaña de terminar venta
+## Cierre de sesión
+Closes #75
+- Se arregló un error en el que al presionar el botón de cerrar sesión en el menú principal la aplicación se cerraba y no cerraba sesión correctamente
 
-### 2. Reimpresión de facturas
-Closes #68
-- Se arregló un error en el que al presionar el botón de "Reimprimir más reciente" en la pestaña de reimpresiones se mostraba un error y no se podía imprimir
-- Se arregló un error relacionado a la selección de la fila con la factura a imprimir en el que a veces al selecionar la primer fila esta no se imprimía correctamente
-- Se eliminó el preview que se generaba al terminar la factura ya que en producción no se consideró necesario ya que este se imprimiría en todo caso
-
-### 3. Actualizaciones de la aplicación
-Closes #73
-- Se arregló un error en el que no se señalizaba de forma correcta que ya se estaba comenzando con el proceso de actualizaicón de la aplicación al buscar versiones nuevas desde la pestaña de configuración
-- Se arregló un error que impedía el funcionamiento correcto de las actualizaciones automáticas
+## Mantenimiento de productos
+- Closes #77: Se arregló un error en el que al terminar de guardar un producto nuevo la pestaña no se cerraba correctamente y se mantenía abierta sin la posibilidad de cerrarla de formas normales
+- Closes #76: Ahora al regresar de las pestañas de agregar o modificar los productos se seleccionará de forma automática todo el texto de la caja de texto de busqueda de productos para poder agregar directamente el siguiente
      

--- a/SistemaFacturación/Data/Cls_CierreCaja.vb
+++ b/SistemaFacturación/Data/Cls_CierreCaja.vb
@@ -92,7 +92,7 @@ Namespace SistemaFacturacion.Data
 
                                       ' Si hay filas, obtiene la fecha de la última fila
                                       If Not Date.TryParse(T.Tables(0).Rows(0).Item("hora_apertura").ToString(), Nothing) Then
-                                          msgError("Error al convertir la fecha de la última apertura de caja.")
+                                          MsgError("Error al convertir la fecha de la última apertura de caja.")
                                           Return New DataTable()
                                       End If
 
@@ -110,18 +110,29 @@ Namespace SistemaFacturacion.Data
                                       }
                                CargarTablaParam(T1, sql, paramList)
 
+                               EntradasEfectivo = 0
+                               SalidasEfectivo = 0
+
                                ' Verifica si la tabla existe o si esta tiene filas
                                If T1.Tables.Count <= 0 OrElse T1.Tables(0).Rows.Count = 0 OrElse IsDBNull(T1.Tables(0).Rows(0).Item("Total")) Then
                                    Log.Warning("No se encontraron movimientos de caja para el arqueo con ID {ArqueoID}.", ID)
                                    ' Si no hay filas, devuelve una nueva DataTable vacía
-                                   EntradasEfectivo = 0
-                                   SalidasEfectivo = 0
                                    Exit Sub
                                End If
 
                                Log.Information("Totales de movimientos de caja obtenidos correctamente para el arqueo con ID {ArqueoID}.", ID)
-                               EntradasEfectivo = T1.Tables(0).Rows(0).Item("total")
-                               SalidasEfectivo = T1.Tables(0).Rows(1).Item("total")
+
+                               For Each row As DataRow In T1.Tables(0).Rows
+                                   If IsDBNull(row.Item("ID_Tipo_Movimiento")) Then
+                                       Continue For
+                                   End If
+                                   Select Case row.Item("ID_Tipo_Movimiento")
+                                       Case 1 'Entrada
+                                           EntradasEfectivo = row.Item("total")
+                                       Case 2 'Salida
+                                           SalidasEfectivo = row.Item("total")
+                                   End Select
+                               Next
                                Log.Information("Totales - Entradas: {Entradas}, Salidas: {Salidas}", EntradasEfectivo, SalidasEfectivo)
                            End Sub)
         End Function

--- a/SistemaFacturación/Forms/Caja/P_Caja.vb
+++ b/SistemaFacturación/Forms/Caja/P_Caja.vb
@@ -658,10 +658,13 @@ Namespace SistemaFacturacion.Forms.Caja
                     .ListaProductos = prodList,
                     .Saldo_total = totalCaja,
                     .Num_factura = NumFactura,
-                    .Tipo_pago = 1,
+                    .Tipo_pago = 0,
                     .Excluir_de_cierre = 0
                 }
-                endVentaForm.isCuentaPorCobrar = False
+                endVentaForm.TXT_ECliente.Text = totalCaja
+                endVentaForm.TXT_DCliente.Text = totalCaja
+                endVentaForm.TXT_SCliente.Text = totalCaja
+                endVentaForm.TXT_TCliente.Text = totalCaja
 
                 'Se pasa el datagrid completo para obtener los datos
                 Dim result As DialogResult = endVentaForm.ShowDialog()

--- a/SistemaFacturación/Forms/Caja/P_TerminarVenta.Designer.vb
+++ b/SistemaFacturación/Forms/Caja/P_TerminarVenta.Designer.vb
@@ -28,6 +28,7 @@
         Me.Guna2BorderlessForm1 = New Guna.UI2.WinForms.Guna2BorderlessForm(Me.components)
         Me.TabControlTVenta = New Guna.UI2.WinForms.Guna2TabControl()
         Me.Efectivo = New System.Windows.Forms.TabPage()
+            Me.TXT_ECliente = New Guna.UI2.WinForms.Guna2TextBox()
             Me.BTN_EColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
             Me.TXT_EVuelto = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel2 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -35,6 +36,7 @@
             Me.TXT_ETotal = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel4 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.Tarjeta = New System.Windows.Forms.TabPage()
+            Me.TXT_TCliente = New Guna.UI2.WinForms.Guna2TextBox()
             Me.BTN_TColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
             Me.TXT_TVuelto = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel3 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -42,6 +44,7 @@
             Me.TXT_TTotal = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel6 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.Sinpe = New System.Windows.Forms.TabPage()
+            Me.TXT_SCliente = New Guna.UI2.WinForms.Guna2TextBox()
             Me.BTN_SColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
             Me.TXT_SVuelto = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel7 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -49,6 +52,7 @@
             Me.TXT_STotal = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel9 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.deposito = New System.Windows.Forms.TabPage()
+            Me.TXT_DCliente = New Guna.UI2.WinForms.Guna2TextBox()
             Me.BTN_DColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
             Me.Guna2HtmlLabel11 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.TXT_DVuelto = New Guna.UI2.WinForms.Guna2TextBox()
@@ -56,6 +60,8 @@
             Me.TXT_DTotal = New Guna.UI2.WinForms.Guna2TextBox()
             Me.Guna2HtmlLabel12 = New Guna.UI2.WinForms.Guna2HtmlLabel()
             Me.Mixto = New System.Windows.Forms.TabPage()
+            Me.TXT_MEfectivo = New Guna.UI2.WinForms.Guna2TextBox()
+            Me.TXT_MTarjeta = New Guna.UI2.WinForms.Guna2TextBox()
             Me.BTN_RestanteEfectivo = New Guna.UI2.WinForms.Guna2TileButton()
             Me.BTN_RestanteTarjeta = New Guna.UI2.WinForms.Guna2TileButton()
             Me.Guna2HtmlLabel16 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -70,12 +76,6 @@
             Me.TXT_Comentario = New Guna.UI2.WinForms.Guna2TextBox()
             Me.BTN_TVentaImp = New Guna.UI2.WinForms.Guna2Button()
             Me.Guna2Panel1 = New Guna.UI2.WinForms.Guna2Panel()
-            Me.TXT_ECliente = New Guna.UI2.WinForms.Guna2TextBox()
-            Me.TXT_TCliente = New Guna.UI2.WinForms.Guna2TextBox()
-            Me.TXT_SCliente = New Guna.UI2.WinForms.Guna2TextBox()
-            Me.TXT_DCliente = New Guna.UI2.WinForms.Guna2TextBox()
-            Me.TXT_MTarjeta = New Guna.UI2.WinForms.Guna2TextBox()
-            Me.TXT_MEfectivo = New Guna.UI2.WinForms.Guna2TextBox()
             Me.TabControlTVenta.SuspendLayout()
             Me.Efectivo.SuspendLayout()
             Me.Tarjeta.SuspendLayout()
@@ -143,6 +143,28 @@
             Me.Efectivo.Size = New System.Drawing.Size(641, 381)
             Me.Efectivo.TabIndex = 0
             Me.Efectivo.Text = "Efectivo"
+            '
+            'TXT_ECliente
+            '
+            Me.TXT_ECliente.BorderRadius = 10
+            Me.TXT_ECliente.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_ECliente.DefaultText = "0"
+            Me.TXT_ECliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_ECliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_ECliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_ECliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_ECliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_ECliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_ECliente.ForeColor = System.Drawing.Color.Black
+            Me.TXT_ECliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_ECliente.Location = New System.Drawing.Point(103, 144)
+            Me.TXT_ECliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_ECliente.Name = "TXT_ECliente"
+            Me.TXT_ECliente.PlaceholderText = ""
+            Me.TXT_ECliente.SelectedText = ""
+            Me.TXT_ECliente.Size = New System.Drawing.Size(439, 42)
+            Me.TXT_ECliente.TabIndex = 109
+            Me.TXT_ECliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
             '
             'BTN_EColocarTotal
             '
@@ -258,6 +280,28 @@
             Me.Tarjeta.TabIndex = 1
             Me.Tarjeta.Text = "Tarjeta"
             '
+            'TXT_TCliente
+            '
+            Me.TXT_TCliente.BorderRadius = 10
+            Me.TXT_TCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_TCliente.DefaultText = "0"
+            Me.TXT_TCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_TCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_TCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_TCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_TCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_TCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_TCliente.ForeColor = System.Drawing.Color.Black
+            Me.TXT_TCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_TCliente.Location = New System.Drawing.Point(101, 156)
+            Me.TXT_TCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_TCliente.Name = "TXT_TCliente"
+            Me.TXT_TCliente.PlaceholderText = ""
+            Me.TXT_TCliente.SelectedText = ""
+            Me.TXT_TCliente.Size = New System.Drawing.Size(439, 42)
+            Me.TXT_TCliente.TabIndex = 114
+            Me.TXT_TCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
             'BTN_TColocarTotal
             '
             Me.BTN_TColocarTotal.BorderRadius = 20
@@ -372,6 +416,28 @@
             Me.Sinpe.TabIndex = 2
             Me.Sinpe.Text = "Sinpe"
             '
+            'TXT_SCliente
+            '
+            Me.TXT_SCliente.BorderRadius = 10
+            Me.TXT_SCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_SCliente.DefaultText = "0"
+            Me.TXT_SCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_SCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_SCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_SCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_SCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_SCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_SCliente.ForeColor = System.Drawing.Color.Black
+            Me.TXT_SCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_SCliente.Location = New System.Drawing.Point(101, 150)
+            Me.TXT_SCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_SCliente.Name = "TXT_SCliente"
+            Me.TXT_SCliente.PlaceholderText = ""
+            Me.TXT_SCliente.SelectedText = ""
+            Me.TXT_SCliente.Size = New System.Drawing.Size(439, 42)
+            Me.TXT_SCliente.TabIndex = 120
+            Me.TXT_SCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
             'BTN_SColocarTotal
             '
             Me.BTN_SColocarTotal.BorderRadius = 20
@@ -485,6 +551,28 @@
             Me.deposito.Size = New System.Drawing.Size(641, 381)
             Me.deposito.TabIndex = 3
             Me.deposito.Text = "Depósito"
+            '
+            'TXT_DCliente
+            '
+            Me.TXT_DCliente.BorderRadius = 10
+            Me.TXT_DCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_DCliente.DefaultText = "0"
+            Me.TXT_DCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_DCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_DCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_DCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_DCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_DCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_DCliente.ForeColor = System.Drawing.Color.Black
+            Me.TXT_DCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_DCliente.Location = New System.Drawing.Point(101, 148)
+            Me.TXT_DCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_DCliente.Name = "TXT_DCliente"
+            Me.TXT_DCliente.PlaceholderText = ""
+            Me.TXT_DCliente.SelectedText = ""
+            Me.TXT_DCliente.Size = New System.Drawing.Size(439, 42)
+            Me.TXT_DCliente.TabIndex = 129
+            Me.TXT_DCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
             '
             'BTN_DColocarTotal
             '
@@ -602,6 +690,50 @@
             Me.Mixto.Size = New System.Drawing.Size(641, 381)
             Me.Mixto.TabIndex = 4
             Me.Mixto.Text = "Mixto"
+            '
+            'TXT_MEfectivo
+            '
+            Me.TXT_MEfectivo.BorderRadius = 10
+            Me.TXT_MEfectivo.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_MEfectivo.DefaultText = "0"
+            Me.TXT_MEfectivo.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_MEfectivo.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_MEfectivo.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_MEfectivo.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_MEfectivo.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_MEfectivo.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_MEfectivo.ForeColor = System.Drawing.Color.Black
+            Me.TXT_MEfectivo.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_MEfectivo.Location = New System.Drawing.Point(329, 146)
+            Me.TXT_MEfectivo.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_MEfectivo.Name = "TXT_MEfectivo"
+            Me.TXT_MEfectivo.PlaceholderText = ""
+            Me.TXT_MEfectivo.SelectedText = ""
+            Me.TXT_MEfectivo.Size = New System.Drawing.Size(300, 42)
+            Me.TXT_MEfectivo.TabIndex = 137
+            Me.TXT_MEfectivo.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+            '
+            'TXT_MTarjeta
+            '
+            Me.TXT_MTarjeta.BorderRadius = 10
+            Me.TXT_MTarjeta.Cursor = System.Windows.Forms.Cursors.IBeam
+            Me.TXT_MTarjeta.DefaultText = "0"
+            Me.TXT_MTarjeta.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+            Me.TXT_MTarjeta.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+            Me.TXT_MTarjeta.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_MTarjeta.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+            Me.TXT_MTarjeta.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_MTarjeta.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.TXT_MTarjeta.ForeColor = System.Drawing.Color.Black
+            Me.TXT_MTarjeta.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.TXT_MTarjeta.Location = New System.Drawing.Point(15, 146)
+            Me.TXT_MTarjeta.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+            Me.TXT_MTarjeta.Name = "TXT_MTarjeta"
+            Me.TXT_MTarjeta.PlaceholderText = ""
+            Me.TXT_MTarjeta.SelectedText = ""
+            Me.TXT_MTarjeta.Size = New System.Drawing.Size(300, 42)
+            Me.TXT_MTarjeta.TabIndex = 136
+            Me.TXT_MTarjeta.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
             '
             'BTN_RestanteEfectivo
             '
@@ -830,138 +962,6 @@
             Me.Guna2Panel1.Name = "Guna2Panel1"
             Me.Guna2Panel1.Size = New System.Drawing.Size(908, 69)
             Me.Guna2Panel1.TabIndex = 131
-            '
-            'TXT_ECliente
-            '
-            Me.TXT_ECliente.BorderRadius = 10
-            Me.TXT_ECliente.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.TXT_ECliente.DefaultText = "0"
-            Me.TXT_ECliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
-            Me.TXT_ECliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
-            Me.TXT_ECliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_ECliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_ECliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_ECliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            Me.TXT_ECliente.ForeColor = System.Drawing.Color.Black
-            Me.TXT_ECliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_ECliente.Location = New System.Drawing.Point(103, 144)
-            Me.TXT_ECliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
-            Me.TXT_ECliente.Name = "TXT_ECliente"
-            Me.TXT_ECliente.PlaceholderText = ""
-            Me.TXT_ECliente.SelectedText = ""
-            Me.TXT_ECliente.Size = New System.Drawing.Size(439, 42)
-            Me.TXT_ECliente.TabIndex = 109
-            Me.TXT_ECliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
-            '
-            'TXT_TCliente
-            '
-            Me.TXT_TCliente.BorderRadius = 10
-            Me.TXT_TCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.TXT_TCliente.DefaultText = "0"
-            Me.TXT_TCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
-            Me.TXT_TCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
-            Me.TXT_TCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_TCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_TCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_TCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            Me.TXT_TCliente.ForeColor = System.Drawing.Color.Black
-            Me.TXT_TCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_TCliente.Location = New System.Drawing.Point(101, 156)
-            Me.TXT_TCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
-            Me.TXT_TCliente.Name = "TXT_TCliente"
-            Me.TXT_TCliente.PlaceholderText = ""
-            Me.TXT_TCliente.SelectedText = ""
-            Me.TXT_TCliente.Size = New System.Drawing.Size(439, 42)
-            Me.TXT_TCliente.TabIndex = 114
-            Me.TXT_TCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
-            '
-            'TXT_SCliente
-            '
-            Me.TXT_SCliente.BorderRadius = 10
-            Me.TXT_SCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.TXT_SCliente.DefaultText = "0"
-            Me.TXT_SCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
-            Me.TXT_SCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
-            Me.TXT_SCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_SCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_SCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_SCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            Me.TXT_SCliente.ForeColor = System.Drawing.Color.Black
-            Me.TXT_SCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_SCliente.Location = New System.Drawing.Point(101, 150)
-            Me.TXT_SCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
-            Me.TXT_SCliente.Name = "TXT_SCliente"
-            Me.TXT_SCliente.PlaceholderText = ""
-            Me.TXT_SCliente.SelectedText = ""
-            Me.TXT_SCliente.Size = New System.Drawing.Size(439, 42)
-            Me.TXT_SCliente.TabIndex = 120
-            Me.TXT_SCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
-            '
-            'TXT_DCliente
-            '
-            Me.TXT_DCliente.BorderRadius = 10
-            Me.TXT_DCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.TXT_DCliente.DefaultText = "0"
-            Me.TXT_DCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
-            Me.TXT_DCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
-            Me.TXT_DCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_DCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_DCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_DCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            Me.TXT_DCliente.ForeColor = System.Drawing.Color.Black
-            Me.TXT_DCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_DCliente.Location = New System.Drawing.Point(101, 148)
-            Me.TXT_DCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
-            Me.TXT_DCliente.Name = "TXT_DCliente"
-            Me.TXT_DCliente.PlaceholderText = ""
-            Me.TXT_DCliente.SelectedText = ""
-            Me.TXT_DCliente.Size = New System.Drawing.Size(439, 42)
-            Me.TXT_DCliente.TabIndex = 129
-            Me.TXT_DCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
-            '
-            'TXT_MTarjeta
-            '
-            Me.TXT_MTarjeta.BorderRadius = 10
-            Me.TXT_MTarjeta.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.TXT_MTarjeta.DefaultText = "0"
-            Me.TXT_MTarjeta.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
-            Me.TXT_MTarjeta.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
-            Me.TXT_MTarjeta.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_MTarjeta.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_MTarjeta.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_MTarjeta.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            Me.TXT_MTarjeta.ForeColor = System.Drawing.Color.Black
-            Me.TXT_MTarjeta.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_MTarjeta.Location = New System.Drawing.Point(15, 146)
-            Me.TXT_MTarjeta.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
-            Me.TXT_MTarjeta.Name = "TXT_MTarjeta"
-            Me.TXT_MTarjeta.PlaceholderText = ""
-            Me.TXT_MTarjeta.SelectedText = ""
-            Me.TXT_MTarjeta.Size = New System.Drawing.Size(300, 42)
-            Me.TXT_MTarjeta.TabIndex = 136
-            Me.TXT_MTarjeta.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
-            '
-            'TXT_MEfectivo
-            '
-            Me.TXT_MEfectivo.BorderRadius = 10
-            Me.TXT_MEfectivo.Cursor = System.Windows.Forms.Cursors.IBeam
-            Me.TXT_MEfectivo.DefaultText = "0"
-            Me.TXT_MEfectivo.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
-            Me.TXT_MEfectivo.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
-            Me.TXT_MEfectivo.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_MEfectivo.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
-            Me.TXT_MEfectivo.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_MEfectivo.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-            Me.TXT_MEfectivo.ForeColor = System.Drawing.Color.Black
-            Me.TXT_MEfectivo.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
-            Me.TXT_MEfectivo.Location = New System.Drawing.Point(329, 146)
-            Me.TXT_MEfectivo.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
-            Me.TXT_MEfectivo.Name = "TXT_MEfectivo"
-            Me.TXT_MEfectivo.PlaceholderText = ""
-            Me.TXT_MEfectivo.SelectedText = ""
-            Me.TXT_MEfectivo.Size = New System.Drawing.Size(300, 42)
-            Me.TXT_MEfectivo.TabIndex = 137
-            Me.TXT_MEfectivo.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
             '
             'P_TerminarVenta
             '

--- a/SistemaFacturación/Forms/Caja/P_TerminarVenta.vb
+++ b/SistemaFacturación/Forms/Caja/P_TerminarVenta.vb
@@ -7,7 +7,6 @@ Namespace SistemaFacturacion.Forms.Caja
     Public Class P_TerminarVenta
         ' Declaración de variables a nivel de la clase
         ' Estas variables se mantienen durante todo el ciclo de vida del formulario
-        Friend isCuentaPorCobrar As Boolean
         Friend venta As Cls_Ventas
         Friend imprimir_factura As Boolean
 
@@ -48,9 +47,6 @@ Namespace SistemaFacturacion.Forms.Caja
                 TXT_DTotal,
                 TXT_MTotal
             }
-            ' Valida el estado inicial del pago y habilita/deshabilita los botones de venta
-            Dim entregaCliente As Decimal = If(Integer.TryParse(TXT_ECliente.Text, entregaCliente), entregaCliente, 0)
-            BTN_TVenta.Enabled = entregaCliente > venta.Saldo_total
         End Sub
         Private Sub P_TerminarVenta_Shown(sender As Object, e As EventArgs) Handles MyBase.Shown
             ' Añade los manejadores de eventos (handlers) para los botones de "Colocar Total"
@@ -71,26 +67,33 @@ Namespace SistemaFacturacion.Forms.Caja
                 AddHandler txt.KeyPress, AddressOf verifyNumericOnKeyPress
             Next
 
-            Dim saldo = If(isCuentaPorCobrar, venta.Saldo_restante, venta.Saldo_total)
             'Se coloca el total en todas las textbox de total
             For Each txt As Guna2TextBox In txtShowTotal
-                txt.Text = saldo
+                txt.Text = venta.Formated_saldo_total
             Next
+
+            ' Valida el estado inicial del pago y habilita/deshabilita los botones de venta
+            Dim entregaCliente As Decimal = If(Integer.TryParse(TXT_ECliente.Text, entregaCliente), entregaCliente, 0)
+            BTN_TVenta.Enabled = entregaCliente >= venta.Saldo_total
+
+            TXT_ECliente.SelectAll()
+            TXT_ECliente.Focus()
         End Sub
 
 #Region "Calculos y validaciones"
 
         Private Sub GetVuelto(entregaCliente As Decimal, txtVuelto As Guna2TextBox)
-            venta.Vuelto = entregaCliente - venta.Saldo_total
-            If venta.Vuelto > 0 Then
-                txtVuelto.Text = venta.Formated_vuelto
+            If entregaCliente >= venta.Saldo_total Then
+                venta.Vuelto = entregaCliente - venta.Saldo_total
             Else
-                txtVuelto.Text = "0"
+                venta.Vuelto = 0
             End If
+
+            txtVuelto.Text = venta.Formated_vuelto
         End Sub
 
         ' Manjeador de evento unificado para la verificación de los montos ingresados
-        Private Sub verifyNumericOnKeyPress(sender As Object, e As KeyPressEventArgs)
+        Private Sub VerifyNumericOnKeyPress(sender As Object, e As KeyPressEventArgs)
             ' 1. Permitir el uso de teclas de control (como Backspace)
             If Char.IsControl(e.KeyChar) Then
                 e.Handled = False
@@ -157,7 +160,7 @@ Namespace SistemaFacturacion.Forms.Caja
 
                 BTN_TVenta.Enabled = entregaCliente >= venta.Saldo_total
 
-                GetVuelto(txt.Text, txtVuelto)
+                GetVuelto(entregaCliente, txtVuelto)
             Catch ex As Exception
                 MsgError("Error al recalcular el vuelto y validar: " & ex.Message)
                 GetVuelto(0, txtVuelto)
@@ -242,8 +245,6 @@ Namespace SistemaFacturacion.Forms.Caja
 #Region "TerminarVenta_ImprimirFactura"
 
         Private Sub TerminarVenta(imprimir As Boolean)
-            venta.Tipo_pago = TabControlTVenta.SelectedIndex
-
             Select Case venta.Tipo_pago
                 Case 0 ' Efectivo
                     If Not Decimal.TryParse(TXT_ECliente.Text, venta.Efectivo) Then
@@ -312,6 +313,24 @@ Namespace SistemaFacturacion.Forms.Caja
                     BTN_TVenta.PerformClick()
                 Case Keys.F4
                     BTN_TVentaImp.PerformClick()
+            End Select
+        End Sub
+
+        Private Sub TabControlTVenta_SelectedIndexChanged(sender As Object, e As EventArgs) Handles TabControlTVenta.SelectedIndexChanged
+            venta.Tipo_pago = TabControlTVenta.SelectedIndex
+            Select Case venta.Tipo_pago
+                Case 0 'efectivo
+                    TXT_ECliente.SelectAll()
+                    TXT_ECliente.Focus()
+                Case 1
+                    TXT_TCliente.SelectAll()
+                    TXT_TCliente.Focus()
+                Case 2
+                    TXT_SCliente.SelectAll()
+                    TXT_SCliente.Focus()
+                Case 3
+                    TXT_DCliente.SelectAll()
+                    TXT_DCliente.Focus()
             End Select
         End Sub
     End Class

--- a/SistemaFacturación/Forms/CuentasXCobrar/P_AbonarCxC.Designer.vb
+++ b/SistemaFacturación/Forms/CuentasXCobrar/P_AbonarCxC.Designer.vb
@@ -26,9 +26,14 @@ Partial Class P_AbonarCxC
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(P_AbonarCxC))
         Me.TXT_Comentario = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel17 = New Guna.UI2.WinForms.Guna2HtmlLabel()
+        Me.BTN_RegresarVenta = New Guna.UI2.WinForms.Guna2Button()
+        Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel()
+        Me.BTN_TVenta = New Guna.UI2.WinForms.Guna2Button()
+        Me.BTN_TVentaImp = New Guna.UI2.WinForms.Guna2Button()
+        Me.Guna2BorderlessForm1 = New Guna.UI2.WinForms.Guna2BorderlessForm(Me.components)
         Me.TabControlTVenta = New Guna.UI2.WinForms.Guna2TabControl()
         Me.Efectivo = New System.Windows.Forms.TabPage()
-        Me.NUD_ECliente = New Guna.UI2.WinForms.Guna2NumericUpDown()
+        Me.TXT_ECliente = New Guna.UI2.WinForms.Guna2TextBox()
         Me.BTN_EColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
         Me.TXT_EVuelto = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel2 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -36,7 +41,7 @@ Partial Class P_AbonarCxC
         Me.TXT_ETotal = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel4 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.Tarjeta = New System.Windows.Forms.TabPage()
-        Me.NUD_TCliente = New Guna.UI2.WinForms.Guna2NumericUpDown()
+        Me.TXT_TCliente = New Guna.UI2.WinForms.Guna2TextBox()
         Me.BTN_TColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
         Me.TXT_TVuelto = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel3 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -44,7 +49,7 @@ Partial Class P_AbonarCxC
         Me.TXT_TTotal = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel6 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.Sinpe = New System.Windows.Forms.TabPage()
-        Me.NUD_SCliente = New Guna.UI2.WinForms.Guna2NumericUpDown()
+        Me.TXT_SCliente = New Guna.UI2.WinForms.Guna2TextBox()
         Me.BTN_SColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
         Me.TXT_SVuelto = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel7 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -52,7 +57,7 @@ Partial Class P_AbonarCxC
         Me.TXT_STotal = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel9 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.deposito = New System.Windows.Forms.TabPage()
-        Me.NUD_DCliente = New Guna.UI2.WinForms.Guna2NumericUpDown()
+        Me.TXT_DCliente = New Guna.UI2.WinForms.Guna2TextBox()
         Me.BTN_DColocarTotal = New Guna.UI2.WinForms.Guna2TileButton()
         Me.Guna2HtmlLabel11 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.TXT_DVuelto = New Guna.UI2.WinForms.Guna2TextBox()
@@ -60,8 +65,8 @@ Partial Class P_AbonarCxC
         Me.TXT_DTotal = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel12 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.Mixto = New System.Windows.Forms.TabPage()
-        Me.NUD_MTarjeta = New Guna.UI2.WinForms.Guna2NumericUpDown()
-        Me.NUD_MEfectivo = New Guna.UI2.WinForms.Guna2NumericUpDown()
+        Me.TXT_MEfectivo = New Guna.UI2.WinForms.Guna2TextBox()
+        Me.TXT_MTarjeta = New Guna.UI2.WinForms.Guna2TextBox()
         Me.BTN_RestanteEfectivo = New Guna.UI2.WinForms.Guna2TileButton()
         Me.BTN_RestanteTarjeta = New Guna.UI2.WinForms.Guna2TileButton()
         Me.Guna2HtmlLabel16 = New Guna.UI2.WinForms.Guna2HtmlLabel()
@@ -70,24 +75,13 @@ Partial Class P_AbonarCxC
         Me.Guna2HtmlLabel14 = New Guna.UI2.WinForms.Guna2HtmlLabel()
         Me.TXT_MTotal = New Guna.UI2.WinForms.Guna2TextBox()
         Me.Guna2HtmlLabel15 = New Guna.UI2.WinForms.Guna2HtmlLabel()
-        Me.BTN_RegresarVenta = New Guna.UI2.WinForms.Guna2Button()
-        Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel()
-        Me.BTN_TVenta = New Guna.UI2.WinForms.Guna2Button()
-        Me.BTN_TVentaImp = New Guna.UI2.WinForms.Guna2Button()
-        Me.Guna2BorderlessForm1 = New Guna.UI2.WinForms.Guna2BorderlessForm(Me.components)
+        Me.TableLayoutPanel1.SuspendLayout()
         Me.TabControlTVenta.SuspendLayout()
         Me.Efectivo.SuspendLayout()
-        CType(Me.NUD_ECliente, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.Tarjeta.SuspendLayout()
-        CType(Me.NUD_TCliente, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.Sinpe.SuspendLayout()
-        CType(Me.NUD_SCliente, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.deposito.SuspendLayout()
-        CType(Me.NUD_DCliente, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.Mixto.SuspendLayout()
-        CType(Me.NUD_MTarjeta, System.ComponentModel.ISupportInitialize).BeginInit()
-        CType(Me.NUD_MEfectivo, System.ComponentModel.ISupportInitialize).BeginInit()
-        Me.TableLayoutPanel1.SuspendLayout()
         Me.SuspendLayout()
         '
         'TXT_Comentario
@@ -107,7 +101,6 @@ Partial Class P_AbonarCxC
         Me.TXT_Comentario.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_Comentario.Multiline = True
         Me.TXT_Comentario.Name = "TXT_Comentario"
-        Me.TXT_Comentario.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_Comentario.PlaceholderText = ""
         Me.TXT_Comentario.SelectedText = ""
         Me.TXT_Comentario.Size = New System.Drawing.Size(745, 86)
@@ -125,6 +118,93 @@ Partial Class P_AbonarCxC
         Me.Guna2HtmlLabel17.Text = "Comentario:"
         Me.Guna2HtmlLabel17.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
         '
+        'BTN_RegresarVenta
+        '
+        Me.BTN_RegresarVenta.BorderColor = System.Drawing.Color.Red
+        Me.BTN_RegresarVenta.BorderRadius = 10
+        Me.BTN_RegresarVenta.DialogResult = System.Windows.Forms.DialogResult.Cancel
+        Me.BTN_RegresarVenta.DisabledState.BorderColor = System.Drawing.Color.DarkGray
+        Me.BTN_RegresarVenta.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
+        Me.BTN_RegresarVenta.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
+        Me.BTN_RegresarVenta.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
+        Me.BTN_RegresarVenta.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.BTN_RegresarVenta.FillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(64, Byte), Integer), CType(CType(64, Byte), Integer))
+        Me.BTN_RegresarVenta.Font = New System.Drawing.Font("Ebrima", 15.75!, System.Drawing.FontStyle.Bold)
+        Me.BTN_RegresarVenta.ForeColor = System.Drawing.Color.White
+        Me.BTN_RegresarVenta.Image = Global.SistemaFacturaciónCommon.My.Resources.Resources.ICO_Back
+        Me.BTN_RegresarVenta.ImageSize = New System.Drawing.Size(45, 45)
+        Me.BTN_RegresarVenta.Location = New System.Drawing.Point(3, 3)
+        Me.BTN_RegresarVenta.Name = "BTN_RegresarVenta"
+        Me.BTN_RegresarVenta.Size = New System.Drawing.Size(297, 60)
+        Me.BTN_RegresarVenta.TabIndex = 132
+        Me.BTN_RegresarVenta.Text = "[F1] Regresar"
+        '
+        'TableLayoutPanel1
+        '
+        Me.TableLayoutPanel1.ColumnCount = 3
+        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333!))
+        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333!))
+        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333!))
+        Me.TableLayoutPanel1.Controls.Add(Me.BTN_TVenta, 2, 0)
+        Me.TableLayoutPanel1.Controls.Add(Me.BTN_TVentaImp, 1, 0)
+        Me.TableLayoutPanel1.Controls.Add(Me.BTN_RegresarVenta, 0, 0)
+        Me.TableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom
+        Me.TableLayoutPanel1.Location = New System.Drawing.Point(0, 496)
+        Me.TableLayoutPanel1.Name = "TableLayoutPanel1"
+        Me.TableLayoutPanel1.RowCount = 1
+        Me.TableLayoutPanel1.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
+        Me.TableLayoutPanel1.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 66.0!))
+        Me.TableLayoutPanel1.Size = New System.Drawing.Size(909, 66)
+        Me.TableLayoutPanel1.TabIndex = 137
+        '
+        'BTN_TVenta
+        '
+        Me.BTN_TVenta.BorderColor = System.Drawing.Color.Red
+        Me.BTN_TVenta.BorderRadius = 10
+        Me.BTN_TVenta.DisabledState.BorderColor = System.Drawing.Color.DarkGray
+        Me.BTN_TVenta.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
+        Me.BTN_TVenta.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
+        Me.BTN_TVenta.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
+        Me.BTN_TVenta.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.BTN_TVenta.FillColor = System.Drawing.Color.MediumSeaGreen
+        Me.BTN_TVenta.Font = New System.Drawing.Font("Ebrima", 15.75!, System.Drawing.FontStyle.Bold)
+        Me.BTN_TVenta.ForeColor = System.Drawing.Color.White
+        Me.BTN_TVenta.Image = Global.SistemaFacturaciónCommon.My.Resources.Resources.ICO_EndSale
+        Me.BTN_TVenta.ImageSize = New System.Drawing.Size(45, 45)
+        Me.BTN_TVenta.Location = New System.Drawing.Point(609, 3)
+        Me.BTN_TVenta.Name = "BTN_TVenta"
+        Me.BTN_TVenta.Size = New System.Drawing.Size(297, 60)
+        Me.BTN_TVenta.TabIndex = 139
+        Me.BTN_TVenta.Text = "[F2] Abonar pago"
+        '
+        'BTN_TVentaImp
+        '
+        Me.BTN_TVentaImp.BorderColor = System.Drawing.Color.Red
+        Me.BTN_TVentaImp.BorderRadius = 10
+        Me.BTN_TVentaImp.DialogResult = System.Windows.Forms.DialogResult.Cancel
+        Me.BTN_TVentaImp.DisabledState.BorderColor = System.Drawing.Color.DarkGray
+        Me.BTN_TVentaImp.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
+        Me.BTN_TVentaImp.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
+        Me.BTN_TVentaImp.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
+        Me.BTN_TVentaImp.Dock = System.Windows.Forms.DockStyle.Right
+        Me.BTN_TVentaImp.FillColor = System.Drawing.Color.DarkOrange
+        Me.BTN_TVentaImp.Font = New System.Drawing.Font("Ebrima", 15.75!, System.Drawing.FontStyle.Bold)
+        Me.BTN_TVentaImp.ForeColor = System.Drawing.Color.White
+        Me.BTN_TVentaImp.Image = Global.SistemaFacturaciónCommon.My.Resources.Resources.ICO_Print
+        Me.BTN_TVentaImp.ImageSize = New System.Drawing.Size(45, 45)
+        Me.BTN_TVentaImp.Location = New System.Drawing.Point(307, 3)
+        Me.BTN_TVentaImp.Name = "BTN_TVentaImp"
+        Me.BTN_TVentaImp.Size = New System.Drawing.Size(296, 60)
+        Me.BTN_TVentaImp.TabIndex = 133
+        Me.BTN_TVentaImp.Text = "[F4] Abonar e imprimir"
+        '
+        'Guna2BorderlessForm1
+        '
+        Me.Guna2BorderlessForm1.BorderRadius = 25
+        Me.Guna2BorderlessForm1.ContainerControl = Me
+        Me.Guna2BorderlessForm1.DockIndicatorTransparencyValue = 0.6R
+        Me.Guna2BorderlessForm1.TransparentWhileDrag = True
+        '
         'TabControlTVenta
         '
         Me.TabControlTVenta.Alignment = System.Windows.Forms.TabAlignment.Right
@@ -133,10 +213,9 @@ Partial Class P_AbonarCxC
         Me.TabControlTVenta.Controls.Add(Me.Sinpe)
         Me.TabControlTVenta.Controls.Add(Me.deposito)
         Me.TabControlTVenta.Controls.Add(Me.Mixto)
-        Me.TabControlTVenta.Dock = System.Windows.Forms.DockStyle.Top
         Me.TabControlTVenta.Font = New System.Drawing.Font("Microsoft Sans Serif", 15.75!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.TabControlTVenta.ItemSize = New System.Drawing.Size(260, 75)
-        Me.TabControlTVenta.Location = New System.Drawing.Point(0, 0)
+        Me.TabControlTVenta.Location = New System.Drawing.Point(3, 0)
         Me.TabControlTVenta.Name = "TabControlTVenta"
         Me.TabControlTVenta.SelectedIndex = 0
         Me.TabControlTVenta.Size = New System.Drawing.Size(909, 389)
@@ -156,14 +235,14 @@ Partial Class P_AbonarCxC
         Me.TabControlTVenta.TabButtonSelectedState.ForeColor = System.Drawing.Color.White
         Me.TabControlTVenta.TabButtonSelectedState.InnerColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
         Me.TabControlTVenta.TabButtonSize = New System.Drawing.Size(260, 75)
-        Me.TabControlTVenta.TabIndex = 131
+        Me.TabControlTVenta.TabIndex = 138
         Me.TabControlTVenta.TabMenuBackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
         Me.TabControlTVenta.TabMenuOrientation = Guna.UI2.WinForms.TabMenuOrientation.VerticalRight
         '
         'Efectivo
         '
         Me.Efectivo.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-        Me.Efectivo.Controls.Add(Me.NUD_ECliente)
+        Me.Efectivo.Controls.Add(Me.TXT_ECliente)
         Me.Efectivo.Controls.Add(Me.BTN_EColocarTotal)
         Me.Efectivo.Controls.Add(Me.TXT_EVuelto)
         Me.Efectivo.Controls.Add(Me.Guna2HtmlLabel2)
@@ -178,18 +257,27 @@ Partial Class P_AbonarCxC
         Me.Efectivo.TabIndex = 0
         Me.Efectivo.Text = "Efectivo"
         '
-        'NUD_ECliente
+        'TXT_ECliente
         '
-        Me.NUD_ECliente.BackColor = System.Drawing.Color.Transparent
-        Me.NUD_ECliente.BorderRadius = 10
-        Me.NUD_ECliente.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.NUD_ECliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-        Me.NUD_ECliente.Location = New System.Drawing.Point(103, 142)
-        Me.NUD_ECliente.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-        Me.NUD_ECliente.Name = "NUD_ECliente"
-        Me.NUD_ECliente.Size = New System.Drawing.Size(439, 42)
-        Me.NUD_ECliente.TabIndex = 107
-        Me.NUD_ECliente.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        Me.TXT_ECliente.BorderRadius = 10
+        Me.TXT_ECliente.Cursor = System.Windows.Forms.Cursors.IBeam
+        Me.TXT_ECliente.DefaultText = "0"
+        Me.TXT_ECliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+        Me.TXT_ECliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+        Me.TXT_ECliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_ECliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_ECliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_ECliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.TXT_ECliente.ForeColor = System.Drawing.Color.Black
+        Me.TXT_ECliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_ECliente.Location = New System.Drawing.Point(103, 144)
+        Me.TXT_ECliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+        Me.TXT_ECliente.Name = "TXT_ECliente"
+        Me.TXT_ECliente.PlaceholderText = ""
+        Me.TXT_ECliente.SelectedText = ""
+        Me.TXT_ECliente.Size = New System.Drawing.Size(439, 42)
+        Me.TXT_ECliente.TabIndex = 109
+        Me.TXT_ECliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         '
         'BTN_EColocarTotal
         '
@@ -208,7 +296,7 @@ Partial Class P_AbonarCxC
         '
         'TXT_EVuelto
         '
-        Me.TXT_EVuelto.BorderRadius = 20
+        Me.TXT_EVuelto.BorderRadius = 10
         Me.TXT_EVuelto.Cursor = System.Windows.Forms.Cursors.IBeam
         Me.TXT_EVuelto.DefaultText = "0"
         Me.TXT_EVuelto.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
@@ -222,7 +310,6 @@ Partial Class P_AbonarCxC
         Me.TXT_EVuelto.Location = New System.Drawing.Point(103, 318)
         Me.TXT_EVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_EVuelto.Name = "TXT_EVuelto"
-        Me.TXT_EVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_EVuelto.PlaceholderText = ""
         Me.TXT_EVuelto.ReadOnly = True
         Me.TXT_EVuelto.SelectedText = ""
@@ -256,7 +343,7 @@ Partial Class P_AbonarCxC
         '
         'TXT_ETotal
         '
-        Me.TXT_ETotal.BorderRadius = 20
+        Me.TXT_ETotal.BorderRadius = 10
         Me.TXT_ETotal.Cursor = System.Windows.Forms.Cursors.IBeam
         Me.TXT_ETotal.DefaultText = ""
         Me.TXT_ETotal.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
@@ -270,7 +357,6 @@ Partial Class P_AbonarCxC
         Me.TXT_ETotal.Location = New System.Drawing.Point(103, 43)
         Me.TXT_ETotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_ETotal.Name = "TXT_ETotal"
-        Me.TXT_ETotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_ETotal.PlaceholderText = ""
         Me.TXT_ETotal.ReadOnly = True
         Me.TXT_ETotal.SelectedText = ""
@@ -283,17 +369,17 @@ Partial Class P_AbonarCxC
         Me.Guna2HtmlLabel4.BackColor = System.Drawing.Color.Transparent
         Me.Guna2HtmlLabel4.Font = New System.Drawing.Font("Segoe UI Black", 15.75!, System.Drawing.FontStyle.Bold)
         Me.Guna2HtmlLabel4.ForeColor = System.Drawing.SystemColors.Control
-        Me.Guna2HtmlLabel4.Location = New System.Drawing.Point(270, 6)
+        Me.Guna2HtmlLabel4.Location = New System.Drawing.Point(291, 5)
         Me.Guna2HtmlLabel4.Name = "Guna2HtmlLabel4"
-        Me.Guna2HtmlLabel4.Size = New System.Drawing.Size(101, 32)
+        Me.Guna2HtmlLabel4.Size = New System.Drawing.Size(63, 32)
         Me.Guna2HtmlLabel4.TabIndex = 98
-        Me.Guna2HtmlLabel4.Text = "Restante:"
+        Me.Guna2HtmlLabel4.Text = "Total:"
         Me.Guna2HtmlLabel4.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
         '
         'Tarjeta
         '
         Me.Tarjeta.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-        Me.Tarjeta.Controls.Add(Me.NUD_TCliente)
+        Me.Tarjeta.Controls.Add(Me.TXT_TCliente)
         Me.Tarjeta.Controls.Add(Me.BTN_TColocarTotal)
         Me.Tarjeta.Controls.Add(Me.TXT_TVuelto)
         Me.Tarjeta.Controls.Add(Me.Guna2HtmlLabel3)
@@ -307,18 +393,27 @@ Partial Class P_AbonarCxC
         Me.Tarjeta.TabIndex = 1
         Me.Tarjeta.Text = "Tarjeta"
         '
-        'NUD_TCliente
+        'TXT_TCliente
         '
-        Me.NUD_TCliente.BackColor = System.Drawing.Color.Transparent
-        Me.NUD_TCliente.BorderRadius = 10
-        Me.NUD_TCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.NUD_TCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-        Me.NUD_TCliente.Location = New System.Drawing.Point(101, 156)
-        Me.NUD_TCliente.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-        Me.NUD_TCliente.Name = "NUD_TCliente"
-        Me.NUD_TCliente.Size = New System.Drawing.Size(439, 42)
-        Me.NUD_TCliente.TabIndex = 114
-        Me.NUD_TCliente.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        Me.TXT_TCliente.BorderRadius = 10
+        Me.TXT_TCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+        Me.TXT_TCliente.DefaultText = "0"
+        Me.TXT_TCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+        Me.TXT_TCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+        Me.TXT_TCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_TCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_TCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_TCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.TXT_TCliente.ForeColor = System.Drawing.Color.Black
+        Me.TXT_TCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_TCliente.Location = New System.Drawing.Point(101, 156)
+        Me.TXT_TCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+        Me.TXT_TCliente.Name = "TXT_TCliente"
+        Me.TXT_TCliente.PlaceholderText = ""
+        Me.TXT_TCliente.SelectedText = ""
+        Me.TXT_TCliente.Size = New System.Drawing.Size(439, 42)
+        Me.TXT_TCliente.TabIndex = 114
+        Me.TXT_TCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         '
         'BTN_TColocarTotal
         '
@@ -351,7 +446,6 @@ Partial Class P_AbonarCxC
         Me.TXT_TVuelto.Location = New System.Drawing.Point(101, 314)
         Me.TXT_TVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_TVuelto.Name = "TXT_TVuelto"
-        Me.TXT_TVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_TVuelto.PlaceholderText = ""
         Me.TXT_TVuelto.ReadOnly = True
         Me.TXT_TVuelto.SelectedText = ""
@@ -399,7 +493,6 @@ Partial Class P_AbonarCxC
         Me.TXT_TTotal.Location = New System.Drawing.Point(101, 55)
         Me.TXT_TTotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_TTotal.Name = "TXT_TTotal"
-        Me.TXT_TTotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_TTotal.PlaceholderText = ""
         Me.TXT_TTotal.ReadOnly = True
         Me.TXT_TTotal.SelectedText = ""
@@ -412,17 +505,17 @@ Partial Class P_AbonarCxC
         Me.Guna2HtmlLabel6.BackColor = System.Drawing.Color.Transparent
         Me.Guna2HtmlLabel6.Font = New System.Drawing.Font("Segoe UI Black", 15.75!, System.Drawing.FontStyle.Bold)
         Me.Guna2HtmlLabel6.ForeColor = System.Drawing.SystemColors.Control
-        Me.Guna2HtmlLabel6.Location = New System.Drawing.Point(268, 15)
+        Me.Guna2HtmlLabel6.Location = New System.Drawing.Point(289, 17)
         Me.Guna2HtmlLabel6.Name = "Guna2HtmlLabel6"
-        Me.Guna2HtmlLabel6.Size = New System.Drawing.Size(101, 32)
+        Me.Guna2HtmlLabel6.Size = New System.Drawing.Size(63, 32)
         Me.Guna2HtmlLabel6.TabIndex = 104
-        Me.Guna2HtmlLabel6.Text = "Restante:"
+        Me.Guna2HtmlLabel6.Text = "Total:"
         Me.Guna2HtmlLabel6.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
         '
         'Sinpe
         '
         Me.Sinpe.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-        Me.Sinpe.Controls.Add(Me.NUD_SCliente)
+        Me.Sinpe.Controls.Add(Me.TXT_SCliente)
         Me.Sinpe.Controls.Add(Me.BTN_SColocarTotal)
         Me.Sinpe.Controls.Add(Me.TXT_SVuelto)
         Me.Sinpe.Controls.Add(Me.Guna2HtmlLabel7)
@@ -436,18 +529,27 @@ Partial Class P_AbonarCxC
         Me.Sinpe.TabIndex = 2
         Me.Sinpe.Text = "Sinpe"
         '
-        'NUD_SCliente
+        'TXT_SCliente
         '
-        Me.NUD_SCliente.BackColor = System.Drawing.Color.Transparent
-        Me.NUD_SCliente.BorderRadius = 10
-        Me.NUD_SCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.NUD_SCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-        Me.NUD_SCliente.Location = New System.Drawing.Point(101, 148)
-        Me.NUD_SCliente.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-        Me.NUD_SCliente.Name = "NUD_SCliente"
-        Me.NUD_SCliente.Size = New System.Drawing.Size(439, 42)
-        Me.NUD_SCliente.TabIndex = 120
-        Me.NUD_SCliente.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        Me.TXT_SCliente.BorderRadius = 10
+        Me.TXT_SCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+        Me.TXT_SCliente.DefaultText = "0"
+        Me.TXT_SCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+        Me.TXT_SCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+        Me.TXT_SCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_SCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_SCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_SCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.TXT_SCliente.ForeColor = System.Drawing.Color.Black
+        Me.TXT_SCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_SCliente.Location = New System.Drawing.Point(101, 150)
+        Me.TXT_SCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+        Me.TXT_SCliente.Name = "TXT_SCliente"
+        Me.TXT_SCliente.PlaceholderText = ""
+        Me.TXT_SCliente.SelectedText = ""
+        Me.TXT_SCliente.Size = New System.Drawing.Size(439, 42)
+        Me.TXT_SCliente.TabIndex = 120
+        Me.TXT_SCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         '
         'BTN_SColocarTotal
         '
@@ -480,7 +582,6 @@ Partial Class P_AbonarCxC
         Me.TXT_SVuelto.Location = New System.Drawing.Point(101, 320)
         Me.TXT_SVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_SVuelto.Name = "TXT_SVuelto"
-        Me.TXT_SVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_SVuelto.PlaceholderText = ""
         Me.TXT_SVuelto.ReadOnly = True
         Me.TXT_SVuelto.SelectedText = ""
@@ -528,7 +629,6 @@ Partial Class P_AbonarCxC
         Me.TXT_STotal.Location = New System.Drawing.Point(101, 51)
         Me.TXT_STotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_STotal.Name = "TXT_STotal"
-        Me.TXT_STotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_STotal.PlaceholderText = ""
         Me.TXT_STotal.ReadOnly = True
         Me.TXT_STotal.SelectedText = ""
@@ -541,17 +641,17 @@ Partial Class P_AbonarCxC
         Me.Guna2HtmlLabel9.BackColor = System.Drawing.Color.Transparent
         Me.Guna2HtmlLabel9.Font = New System.Drawing.Font("Segoe UI Black", 15.75!, System.Drawing.FontStyle.Bold)
         Me.Guna2HtmlLabel9.ForeColor = System.Drawing.SystemColors.Control
-        Me.Guna2HtmlLabel9.Location = New System.Drawing.Point(271, 11)
+        Me.Guna2HtmlLabel9.Location = New System.Drawing.Point(289, 13)
         Me.Guna2HtmlLabel9.Name = "Guna2HtmlLabel9"
-        Me.Guna2HtmlLabel9.Size = New System.Drawing.Size(101, 32)
+        Me.Guna2HtmlLabel9.Size = New System.Drawing.Size(63, 32)
         Me.Guna2HtmlLabel9.TabIndex = 113
-        Me.Guna2HtmlLabel9.Text = "Restante:"
+        Me.Guna2HtmlLabel9.Text = "Total:"
         Me.Guna2HtmlLabel9.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
         '
         'deposito
         '
         Me.deposito.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-        Me.deposito.Controls.Add(Me.NUD_DCliente)
+        Me.deposito.Controls.Add(Me.TXT_DCliente)
         Me.deposito.Controls.Add(Me.BTN_DColocarTotal)
         Me.deposito.Controls.Add(Me.Guna2HtmlLabel11)
         Me.deposito.Controls.Add(Me.TXT_DVuelto)
@@ -565,18 +665,27 @@ Partial Class P_AbonarCxC
         Me.deposito.TabIndex = 3
         Me.deposito.Text = "Depósito"
         '
-        'NUD_DCliente
+        'TXT_DCliente
         '
-        Me.NUD_DCliente.BackColor = System.Drawing.Color.Transparent
-        Me.NUD_DCliente.BorderRadius = 10
-        Me.NUD_DCliente.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.NUD_DCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-        Me.NUD_DCliente.Location = New System.Drawing.Point(101, 146)
-        Me.NUD_DCliente.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-        Me.NUD_DCliente.Name = "NUD_DCliente"
-        Me.NUD_DCliente.Size = New System.Drawing.Size(439, 42)
-        Me.NUD_DCliente.TabIndex = 129
-        Me.NUD_DCliente.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        Me.TXT_DCliente.BorderRadius = 10
+        Me.TXT_DCliente.Cursor = System.Windows.Forms.Cursors.IBeam
+        Me.TXT_DCliente.DefaultText = "0"
+        Me.TXT_DCliente.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+        Me.TXT_DCliente.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+        Me.TXT_DCliente.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_DCliente.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_DCliente.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_DCliente.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.TXT_DCliente.ForeColor = System.Drawing.Color.Black
+        Me.TXT_DCliente.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_DCliente.Location = New System.Drawing.Point(101, 148)
+        Me.TXT_DCliente.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+        Me.TXT_DCliente.Name = "TXT_DCliente"
+        Me.TXT_DCliente.PlaceholderText = ""
+        Me.TXT_DCliente.SelectedText = ""
+        Me.TXT_DCliente.Size = New System.Drawing.Size(439, 42)
+        Me.TXT_DCliente.TabIndex = 129
+        Me.TXT_DCliente.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         '
         'BTN_DColocarTotal
         '
@@ -621,7 +730,6 @@ Partial Class P_AbonarCxC
         Me.TXT_DVuelto.Location = New System.Drawing.Point(101, 322)
         Me.TXT_DVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_DVuelto.Name = "TXT_DVuelto"
-        Me.TXT_DVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_DVuelto.PlaceholderText = ""
         Me.TXT_DVuelto.ReadOnly = True
         Me.TXT_DVuelto.SelectedText = ""
@@ -657,7 +765,6 @@ Partial Class P_AbonarCxC
         Me.TXT_DTotal.Location = New System.Drawing.Point(101, 50)
         Me.TXT_DTotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_DTotal.Name = "TXT_DTotal"
-        Me.TXT_DTotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_DTotal.PlaceholderText = ""
         Me.TXT_DTotal.ReadOnly = True
         Me.TXT_DTotal.SelectedText = ""
@@ -670,18 +777,18 @@ Partial Class P_AbonarCxC
         Me.Guna2HtmlLabel12.BackColor = System.Drawing.Color.Transparent
         Me.Guna2HtmlLabel12.Font = New System.Drawing.Font("Segoe UI Black", 15.75!, System.Drawing.FontStyle.Bold)
         Me.Guna2HtmlLabel12.ForeColor = System.Drawing.SystemColors.Control
-        Me.Guna2HtmlLabel12.Location = New System.Drawing.Point(271, 8)
+        Me.Guna2HtmlLabel12.Location = New System.Drawing.Point(289, 12)
         Me.Guna2HtmlLabel12.Name = "Guna2HtmlLabel12"
-        Me.Guna2HtmlLabel12.Size = New System.Drawing.Size(101, 32)
+        Me.Guna2HtmlLabel12.Size = New System.Drawing.Size(63, 32)
         Me.Guna2HtmlLabel12.TabIndex = 120
-        Me.Guna2HtmlLabel12.Text = "Restante:"
+        Me.Guna2HtmlLabel12.Text = "Total:"
         Me.Guna2HtmlLabel12.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
         '
         'Mixto
         '
         Me.Mixto.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
-        Me.Mixto.Controls.Add(Me.NUD_MTarjeta)
-        Me.Mixto.Controls.Add(Me.NUD_MEfectivo)
+        Me.Mixto.Controls.Add(Me.TXT_MEfectivo)
+        Me.Mixto.Controls.Add(Me.TXT_MTarjeta)
         Me.Mixto.Controls.Add(Me.BTN_RestanteEfectivo)
         Me.Mixto.Controls.Add(Me.BTN_RestanteTarjeta)
         Me.Mixto.Controls.Add(Me.Guna2HtmlLabel16)
@@ -697,31 +804,49 @@ Partial Class P_AbonarCxC
         Me.Mixto.TabIndex = 4
         Me.Mixto.Text = "Mixto"
         '
-        'NUD_MTarjeta
+        'TXT_MEfectivo
         '
-        Me.NUD_MTarjeta.BackColor = System.Drawing.Color.Transparent
-        Me.NUD_MTarjeta.BorderRadius = 10
-        Me.NUD_MTarjeta.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.NUD_MTarjeta.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-        Me.NUD_MTarjeta.Location = New System.Drawing.Point(15, 146)
-        Me.NUD_MTarjeta.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-        Me.NUD_MTarjeta.Name = "NUD_MTarjeta"
-        Me.NUD_MTarjeta.Size = New System.Drawing.Size(300, 42)
-        Me.NUD_MTarjeta.TabIndex = 134
-        Me.NUD_MTarjeta.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        Me.TXT_MEfectivo.BorderRadius = 10
+        Me.TXT_MEfectivo.Cursor = System.Windows.Forms.Cursors.IBeam
+        Me.TXT_MEfectivo.DefaultText = "0"
+        Me.TXT_MEfectivo.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+        Me.TXT_MEfectivo.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+        Me.TXT_MEfectivo.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_MEfectivo.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_MEfectivo.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_MEfectivo.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.TXT_MEfectivo.ForeColor = System.Drawing.Color.Black
+        Me.TXT_MEfectivo.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_MEfectivo.Location = New System.Drawing.Point(329, 146)
+        Me.TXT_MEfectivo.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+        Me.TXT_MEfectivo.Name = "TXT_MEfectivo"
+        Me.TXT_MEfectivo.PlaceholderText = ""
+        Me.TXT_MEfectivo.SelectedText = ""
+        Me.TXT_MEfectivo.Size = New System.Drawing.Size(300, 42)
+        Me.TXT_MEfectivo.TabIndex = 137
+        Me.TXT_MEfectivo.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         '
-        'NUD_MEfectivo
+        'TXT_MTarjeta
         '
-        Me.NUD_MEfectivo.BackColor = System.Drawing.Color.Transparent
-        Me.NUD_MEfectivo.BorderRadius = 10
-        Me.NUD_MEfectivo.Cursor = System.Windows.Forms.Cursors.IBeam
-        Me.NUD_MEfectivo.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold)
-        Me.NUD_MEfectivo.Location = New System.Drawing.Point(329, 146)
-        Me.NUD_MEfectivo.Maximum = New Decimal(New Integer() {1000000000, 0, 0, 0})
-        Me.NUD_MEfectivo.Name = "NUD_MEfectivo"
-        Me.NUD_MEfectivo.Size = New System.Drawing.Size(300, 42)
-        Me.NUD_MEfectivo.TabIndex = 133
-        Me.NUD_MEfectivo.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
+        Me.TXT_MTarjeta.BorderRadius = 10
+        Me.TXT_MTarjeta.Cursor = System.Windows.Forms.Cursors.IBeam
+        Me.TXT_MTarjeta.DefaultText = "0"
+        Me.TXT_MTarjeta.DisabledState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer), CType(CType(208, Byte), Integer))
+        Me.TXT_MTarjeta.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer), CType(CType(226, Byte), Integer))
+        Me.TXT_MTarjeta.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_MTarjeta.DisabledState.PlaceholderForeColor = System.Drawing.Color.FromArgb(CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer), CType(CType(138, Byte), Integer))
+        Me.TXT_MTarjeta.FocusedState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_MTarjeta.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.TXT_MTarjeta.ForeColor = System.Drawing.Color.Black
+        Me.TXT_MTarjeta.HoverState.BorderColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(148, Byte), Integer), CType(CType(255, Byte), Integer))
+        Me.TXT_MTarjeta.Location = New System.Drawing.Point(15, 146)
+        Me.TXT_MTarjeta.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
+        Me.TXT_MTarjeta.Name = "TXT_MTarjeta"
+        Me.TXT_MTarjeta.PlaceholderText = ""
+        Me.TXT_MTarjeta.SelectedText = ""
+        Me.TXT_MTarjeta.Size = New System.Drawing.Size(300, 42)
+        Me.TXT_MTarjeta.TabIndex = 136
+        Me.TXT_MTarjeta.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         '
         'BTN_RestanteEfectivo
         '
@@ -781,7 +906,6 @@ Partial Class P_AbonarCxC
         Me.TXT_MVuelto.Location = New System.Drawing.Point(109, 311)
         Me.TXT_MVuelto.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_MVuelto.Name = "TXT_MVuelto"
-        Me.TXT_MVuelto.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_MVuelto.PlaceholderText = ""
         Me.TXT_MVuelto.ReadOnly = True
         Me.TXT_MVuelto.SelectedText = ""
@@ -829,7 +953,6 @@ Partial Class P_AbonarCxC
         Me.TXT_MTotal.Location = New System.Drawing.Point(109, 42)
         Me.TXT_MTotal.Margin = New System.Windows.Forms.Padding(5, 5, 5, 5)
         Me.TXT_MTotal.Name = "TXT_MTotal"
-        Me.TXT_MTotal.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
         Me.TXT_MTotal.PlaceholderText = ""
         Me.TXT_MTotal.ReadOnly = True
         Me.TXT_MTotal.SelectedText = ""
@@ -842,98 +965,12 @@ Partial Class P_AbonarCxC
         Me.Guna2HtmlLabel15.BackColor = System.Drawing.Color.Transparent
         Me.Guna2HtmlLabel15.Font = New System.Drawing.Font("Segoe UI Black", 15.75!, System.Drawing.FontStyle.Bold)
         Me.Guna2HtmlLabel15.ForeColor = System.Drawing.SystemColors.Control
-        Me.Guna2HtmlLabel15.Location = New System.Drawing.Point(274, 6)
+        Me.Guna2HtmlLabel15.Location = New System.Drawing.Point(297, 4)
         Me.Guna2HtmlLabel15.Name = "Guna2HtmlLabel15"
-        Me.Guna2HtmlLabel15.Size = New System.Drawing.Size(101, 32)
+        Me.Guna2HtmlLabel15.Size = New System.Drawing.Size(63, 32)
         Me.Guna2HtmlLabel15.TabIndex = 120
-        Me.Guna2HtmlLabel15.Text = "Restante:"
+        Me.Guna2HtmlLabel15.Text = "Total:"
         Me.Guna2HtmlLabel15.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit
-        '
-        'BTN_RegresarVenta
-        '
-        Me.BTN_RegresarVenta.BorderColor = System.Drawing.Color.Red
-        Me.BTN_RegresarVenta.BorderRadius = 10
-        Me.BTN_RegresarVenta.DialogResult = System.Windows.Forms.DialogResult.Cancel
-        Me.BTN_RegresarVenta.DisabledState.BorderColor = System.Drawing.Color.DarkGray
-        Me.BTN_RegresarVenta.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
-        Me.BTN_RegresarVenta.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
-        Me.BTN_RegresarVenta.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
-        Me.BTN_RegresarVenta.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.BTN_RegresarVenta.FillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(64, Byte), Integer), CType(CType(64, Byte), Integer))
-        Me.BTN_RegresarVenta.Font = New System.Drawing.Font("Ebrima", 15.75!, System.Drawing.FontStyle.Bold)
-        Me.BTN_RegresarVenta.ForeColor = System.Drawing.Color.White
-        Me.BTN_RegresarVenta.Image = Global.SistemaFacturaciónCommon.My.Resources.Resources.ICO_Back
-        Me.BTN_RegresarVenta.ImageSize = New System.Drawing.Size(45, 45)
-        Me.BTN_RegresarVenta.Location = New System.Drawing.Point(3, 3)
-        Me.BTN_RegresarVenta.Name = "BTN_RegresarVenta"
-        Me.BTN_RegresarVenta.Size = New System.Drawing.Size(297, 60)
-        Me.BTN_RegresarVenta.TabIndex = 132
-        Me.BTN_RegresarVenta.Text = "[F1] Regresar"
-        '
-        'TableLayoutPanel1
-        '
-        Me.TableLayoutPanel1.ColumnCount = 3
-        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333!))
-        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333!))
-        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333!))
-        Me.TableLayoutPanel1.Controls.Add(Me.BTN_TVenta, 2, 0)
-        Me.TableLayoutPanel1.Controls.Add(Me.BTN_TVentaImp, 1, 0)
-        Me.TableLayoutPanel1.Controls.Add(Me.BTN_RegresarVenta, 0, 0)
-        Me.TableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom
-        Me.TableLayoutPanel1.Location = New System.Drawing.Point(0, 496)
-        Me.TableLayoutPanel1.Name = "TableLayoutPanel1"
-        Me.TableLayoutPanel1.RowCount = 1
-        Me.TableLayoutPanel1.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.TableLayoutPanel1.Size = New System.Drawing.Size(909, 66)
-        Me.TableLayoutPanel1.TabIndex = 137
-        '
-        'BTN_TVenta
-        '
-        Me.BTN_TVenta.BorderColor = System.Drawing.Color.Red
-        Me.BTN_TVenta.BorderRadius = 10
-        Me.BTN_TVenta.DisabledState.BorderColor = System.Drawing.Color.DarkGray
-        Me.BTN_TVenta.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
-        Me.BTN_TVenta.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
-        Me.BTN_TVenta.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
-        Me.BTN_TVenta.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.BTN_TVenta.FillColor = System.Drawing.Color.MediumSeaGreen
-        Me.BTN_TVenta.Font = New System.Drawing.Font("Ebrima", 15.75!, System.Drawing.FontStyle.Bold)
-        Me.BTN_TVenta.ForeColor = System.Drawing.Color.White
-        Me.BTN_TVenta.Image = Global.SistemaFacturaciónCommon.My.Resources.Resources.ICO_EndSale
-        Me.BTN_TVenta.ImageSize = New System.Drawing.Size(45, 45)
-        Me.BTN_TVenta.Location = New System.Drawing.Point(609, 3)
-        Me.BTN_TVenta.Name = "BTN_TVenta"
-        Me.BTN_TVenta.Size = New System.Drawing.Size(297, 60)
-        Me.BTN_TVenta.TabIndex = 139
-        Me.BTN_TVenta.Text = "[F2] Abonar pago"
-        '
-        'BTN_TVentaImp
-        '
-        Me.BTN_TVentaImp.BorderColor = System.Drawing.Color.Red
-        Me.BTN_TVentaImp.BorderRadius = 10
-        Me.BTN_TVentaImp.DialogResult = System.Windows.Forms.DialogResult.Cancel
-        Me.BTN_TVentaImp.DisabledState.BorderColor = System.Drawing.Color.DarkGray
-        Me.BTN_TVentaImp.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
-        Me.BTN_TVentaImp.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
-        Me.BTN_TVentaImp.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
-        Me.BTN_TVentaImp.Dock = System.Windows.Forms.DockStyle.Right
-        Me.BTN_TVentaImp.FillColor = System.Drawing.Color.DarkOrange
-        Me.BTN_TVentaImp.Font = New System.Drawing.Font("Ebrima", 15.75!, System.Drawing.FontStyle.Bold)
-        Me.BTN_TVentaImp.ForeColor = System.Drawing.Color.White
-        Me.BTN_TVentaImp.Image = Global.SistemaFacturaciónCommon.My.Resources.Resources.ICO_Print
-        Me.BTN_TVentaImp.ImageSize = New System.Drawing.Size(45, 45)
-        Me.BTN_TVentaImp.Location = New System.Drawing.Point(307, 3)
-        Me.BTN_TVentaImp.Name = "BTN_TVentaImp"
-        Me.BTN_TVentaImp.Size = New System.Drawing.Size(296, 60)
-        Me.BTN_TVentaImp.TabIndex = 133
-        Me.BTN_TVentaImp.Text = "[F4] Abonar e imprimir"
-        '
-        'Guna2BorderlessForm1
-        '
-        Me.Guna2BorderlessForm1.BorderRadius = 25
-        Me.Guna2BorderlessForm1.ContainerControl = Me
-        Me.Guna2BorderlessForm1.DockIndicatorTransparencyValue = 0.6R
-        Me.Guna2BorderlessForm1.TransparentWhileDrag = True
         '
         'P_AbonarCxC
         '
@@ -941,34 +978,28 @@ Partial Class P_AbonarCxC
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
         Me.ClientSize = New System.Drawing.Size(909, 562)
+        Me.Controls.Add(Me.TabControlTVenta)
         Me.Controls.Add(Me.TableLayoutPanel1)
         Me.Controls.Add(Me.TXT_Comentario)
         Me.Controls.Add(Me.Guna2HtmlLabel17)
-        Me.Controls.Add(Me.TabControlTVenta)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None
         Me.Icon = CType(resources.GetObject("$this.Icon"), System.Drawing.Icon)
         Me.KeyPreview = True
         Me.Name = "P_AbonarCxC"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
         Me.Text = "Abonar a cuenta por cobrar"
+        Me.TableLayoutPanel1.ResumeLayout(False)
         Me.TabControlTVenta.ResumeLayout(False)
         Me.Efectivo.ResumeLayout(False)
         Me.Efectivo.PerformLayout()
-        CType(Me.NUD_ECliente, System.ComponentModel.ISupportInitialize).EndInit()
         Me.Tarjeta.ResumeLayout(False)
         Me.Tarjeta.PerformLayout()
-        CType(Me.NUD_TCliente, System.ComponentModel.ISupportInitialize).EndInit()
         Me.Sinpe.ResumeLayout(False)
         Me.Sinpe.PerformLayout()
-        CType(Me.NUD_SCliente, System.ComponentModel.ISupportInitialize).EndInit()
         Me.deposito.ResumeLayout(False)
         Me.deposito.PerformLayout()
-        CType(Me.NUD_DCliente, System.ComponentModel.ISupportInitialize).EndInit()
         Me.Mixto.ResumeLayout(False)
         Me.Mixto.PerformLayout()
-        CType(Me.NUD_MTarjeta, System.ComponentModel.ISupportInitialize).EndInit()
-        CType(Me.NUD_MEfectivo, System.ComponentModel.ISupportInitialize).EndInit()
-        Me.TableLayoutPanel1.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -976,8 +1007,14 @@ Partial Class P_AbonarCxC
 
     Friend WithEvents TXT_Comentario As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel17 As Guna.UI2.WinForms.Guna2HtmlLabel
+    Friend WithEvents BTN_RegresarVenta As Guna.UI2.WinForms.Guna2Button
+    Friend WithEvents TableLayoutPanel1 As TableLayoutPanel
+    Friend WithEvents Guna2BorderlessForm1 As Guna.UI2.WinForms.Guna2BorderlessForm
+    Friend WithEvents BTN_TVentaImp As Guna.UI2.WinForms.Guna2Button
+    Friend WithEvents BTN_TVenta As Guna.UI2.WinForms.Guna2Button
     Friend WithEvents TabControlTVenta As Guna.UI2.WinForms.Guna2TabControl
     Friend WithEvents Efectivo As TabPage
+    Friend WithEvents TXT_ECliente As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents BTN_EColocarTotal As Guna.UI2.WinForms.Guna2TileButton
     Friend WithEvents TXT_EVuelto As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel2 As Guna.UI2.WinForms.Guna2HtmlLabel
@@ -985,6 +1022,7 @@ Partial Class P_AbonarCxC
     Friend WithEvents TXT_ETotal As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel4 As Guna.UI2.WinForms.Guna2HtmlLabel
     Friend WithEvents Tarjeta As TabPage
+    Friend WithEvents TXT_TCliente As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents BTN_TColocarTotal As Guna.UI2.WinForms.Guna2TileButton
     Friend WithEvents TXT_TVuelto As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel3 As Guna.UI2.WinForms.Guna2HtmlLabel
@@ -992,6 +1030,7 @@ Partial Class P_AbonarCxC
     Friend WithEvents TXT_TTotal As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel6 As Guna.UI2.WinForms.Guna2HtmlLabel
     Friend WithEvents Sinpe As TabPage
+    Friend WithEvents TXT_SCliente As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents BTN_SColocarTotal As Guna.UI2.WinForms.Guna2TileButton
     Friend WithEvents TXT_SVuelto As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel7 As Guna.UI2.WinForms.Guna2HtmlLabel
@@ -999,6 +1038,7 @@ Partial Class P_AbonarCxC
     Friend WithEvents TXT_STotal As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel9 As Guna.UI2.WinForms.Guna2HtmlLabel
     Friend WithEvents deposito As TabPage
+    Friend WithEvents TXT_DCliente As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents BTN_DColocarTotal As Guna.UI2.WinForms.Guna2TileButton
     Friend WithEvents Guna2HtmlLabel11 As Guna.UI2.WinForms.Guna2HtmlLabel
     Friend WithEvents TXT_DVuelto As Guna.UI2.WinForms.Guna2TextBox
@@ -1006,6 +1046,8 @@ Partial Class P_AbonarCxC
     Friend WithEvents TXT_DTotal As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel12 As Guna.UI2.WinForms.Guna2HtmlLabel
     Friend WithEvents Mixto As TabPage
+    Friend WithEvents TXT_MEfectivo As Guna.UI2.WinForms.Guna2TextBox
+    Friend WithEvents TXT_MTarjeta As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents BTN_RestanteEfectivo As Guna.UI2.WinForms.Guna2TileButton
     Friend WithEvents BTN_RestanteTarjeta As Guna.UI2.WinForms.Guna2TileButton
     Friend WithEvents Guna2HtmlLabel16 As Guna.UI2.WinForms.Guna2HtmlLabel
@@ -1014,15 +1056,4 @@ Partial Class P_AbonarCxC
     Friend WithEvents Guna2HtmlLabel14 As Guna.UI2.WinForms.Guna2HtmlLabel
     Friend WithEvents TXT_MTotal As Guna.UI2.WinForms.Guna2TextBox
     Friend WithEvents Guna2HtmlLabel15 As Guna.UI2.WinForms.Guna2HtmlLabel
-    Friend WithEvents BTN_RegresarVenta As Guna.UI2.WinForms.Guna2Button
-    Friend WithEvents TableLayoutPanel1 As TableLayoutPanel
-    Friend WithEvents Guna2BorderlessForm1 As Guna.UI2.WinForms.Guna2BorderlessForm
-    Friend WithEvents NUD_ECliente As Guna.UI2.WinForms.Guna2NumericUpDown
-    Friend WithEvents NUD_TCliente As Guna.UI2.WinForms.Guna2NumericUpDown
-    Friend WithEvents NUD_SCliente As Guna.UI2.WinForms.Guna2NumericUpDown
-    Friend WithEvents NUD_DCliente As Guna.UI2.WinForms.Guna2NumericUpDown
-    Friend WithEvents NUD_MEfectivo As Guna.UI2.WinForms.Guna2NumericUpDown
-    Friend WithEvents NUD_MTarjeta As Guna.UI2.WinForms.Guna2NumericUpDown
-    Friend WithEvents BTN_TVentaImp As Guna.UI2.WinForms.Guna2Button
-    Friend WithEvents BTN_TVenta As Guna.UI2.WinForms.Guna2Button
 End Class

--- a/SistemaFacturación/Forms/CuentasXCobrar/P_AbonarCxC.vb
+++ b/SistemaFacturación/Forms/CuentasXCobrar/P_AbonarCxC.vb
@@ -2,6 +2,7 @@
 Imports SistemaFacturaciónCommon.SistemaFacturacion.Data
 Imports SistemaFacturaciónCommon.SistemaFacturacion.Forms.Busqueda
 Imports SistemaFacturaciónCommon.SistemaFacturacion.Modules.Md_Inicializacion
+Imports SistemaFacturaciónCommon.SistemaFacturacion.Modules.MSG
 
 Public Class P_AbonarCxC
 
@@ -17,7 +18,7 @@ Public Class P_AbonarCxC
 
     Private btnTotalesList As List(Of Guna2TileButton)
     Private btnRestanteList As List(Of Guna2TileButton)
-    Private nudcalcVuelto As List(Of Guna2NumericUpDown)
+    Private txtEntregaCliente As List(Of Guna2TextBox)
     Private txtShowTotal As List(Of Guna2TextBox)
     Private Sub P_AbonarCxC_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         ' Inicialización de las listas (Solución)
@@ -29,13 +30,13 @@ Public Class P_AbonarCxC
         }
         btnRestanteList = New List(Of Guna2TileButton) From {BTN_RestanteEfectivo, BTN_RestanteTarjeta}
 
-        nudcalcVuelto = New List(Of Guna2NumericUpDown) From {
-            NUD_ECliente,
-            NUD_TCliente,
-            NUD_SCliente,
-            NUD_DCliente,
-            NUD_MEfectivo,
-            NUD_MTarjeta
+        txtEntregaCliente = New List(Of Guna2TextBox) From {
+            TXT_ECliente,
+            TXT_TCliente,
+            TXT_SCliente,
+            TXT_DCliente,
+            TXT_MEfectivo,
+            TXT_MTarjeta
         }
         txtShowTotal = New List(Of Guna2TextBox) From {
             TXT_ETotal,
@@ -44,8 +45,6 @@ Public Class P_AbonarCxC
             TXT_DTotal,
             TXT_MTotal
         }
-        ' Valida el estado inicial del pago y habilita/deshabilita los botones de venta
-        BTN_TVenta.Enabled = NUD_ECliente.Value > 0
     End Sub
 
     Private Sub P_TerminarVenta_Shown(sender As Object, e As EventArgs) Handles MyBase.Shown
@@ -62,47 +61,70 @@ Public Class P_AbonarCxC
 
         ' Añade los manejadores de eventos para los cambios en los TextBox de pago
         ' Esto asegura que el cálculo del vuelto y la validación se actualicen automáticamente
-        For Each txt As Guna2NumericUpDown In nudcalcVuelto
-            AddHandler txt.ValueChanged, AddressOf RecalcularVueltoYValidar
+        For Each txt As Guna2TextBox In txtEntregaCliente
+            AddHandler txt.TextChanged, AddressOf RecalcularVueltoYValidar
+            AddHandler txt.KeyPress, AddressOf verifyNumericOnKeyPress
         Next
         'Se coloca el total en todas las textbox de total
         For Each txt As Guna2TextBox In txtShowTotal
             txt.Text = venta.Formated_saldo_restante
         Next
+
+        ' Valida el estado inicial del pago y habilita/deshabilita los botones de venta
+        Dim entregaCliente As Decimal = If(Integer.TryParse(TXT_ECliente.Text, entregaCliente), entregaCliente, 0)
+        BTN_TVenta.Enabled = entregaCliente > 0
+
+        TXT_ECliente.SelectAll()
+        TXT_ECliente.Focus()
     End Sub
 
 
     ' Manejador de evento unificado para los cambios en los TextBox de pago
     Private Sub RecalcularVueltoYValidar(sender As Object, e As EventArgs)
         ' Convierte el objeto sender al tipo de control Guna2TextBox
-        Dim nud As Guna2NumericUpDown = CType(sender, Guna2NumericUpDown)
-
-        Dim entregaCliente As Decimal = nud.Value
-        If nud.Name = "TXT_PagoTarjeta" Or nud.Name = "TXT_PagoEfectivo" Then
-            entregaCliente = NUD_MEfectivo.Value + NUD_MTarjeta.Value
-        End If
+        Dim txt As Guna2TextBox = CType(sender, Guna2TextBox)
+        Dim entregaCliente As Decimal
         Dim txtVuelto As Guna2TextBox
 
-        Select Case nud.Name
-            Case "NUD_ECliente"
-                entregaCliente = nud.Value
-                txtVuelto = TXT_EVuelto
-            Case "NUD_TCliente"
-                entregaCliente = nud.Value
-                txtVuelto = TXT_TVuelto
-            Case "NUD_SCliente"
-                entregaCliente = nud.Value
-                txtVuelto = TXT_SVuelto
-            Case "NUD_DCliente"
-                entregaCliente = nud.Value
-                txtVuelto = TXT_DVuelto
-            Case Else
-                entregaCliente = NUD_MEfectivo.Value + NUD_MTarjeta.Value
-                txtVuelto = TXT_MVuelto
-        End Select
+        Try
+            Select Case txt.Name
+                Case "TXT_ECliente"
+                    txtVuelto = TXT_EVuelto
+                Case "TXT_TCliente"
+                    txtVuelto = TXT_TVuelto
+                Case "TXT_SCliente"
+                    txtVuelto = TXT_SVuelto
+                Case "TXT_DCliente"
+                    txtVuelto = TXT_DVuelto
+                Case Else
+                    txtVuelto = TXT_MVuelto
+            End Select
+            If Not Decimal.TryParse(If(String.IsNullOrEmpty(txt.Text), 0, txt.Text), entregaCliente) Then
+                MsgError($"El monto ingresado no es válido. No se puede pasar a Decimal el monto: {txt.Text}")
+                Exit Sub
+            End If
+            Dim efectivo As Decimal
+            Dim tarjeta As Decimal
+            If txt.Name = "TXT_MEfectivo" Or txt.Name = "TXT_MTarjeta" Then
+                If Not Decimal.TryParse(TXT_MEfectivo.Text, efectivo) Then
+                    MsgError($"El monto en efectivo ingresado no es válido. No se puede pasar a Decimal el monto: {TXT_MEfectivo.Text}")
+                    Exit Sub
+                End If
+                If Not Decimal.TryParse(TXT_MTarjeta.Text, tarjeta) Then
+                    MsgError($"El monto en tarjeta ingresado no es válido. No se puede pasar a Decimal el monto: {TXT_MTarjeta.Text}")
+                    Exit Sub
+                End If
 
-        GetVuelto(nud.Value, txtVuelto)
-        BTN_TVenta.Enabled = nud.Value > 0
+                entregaCliente = efectivo + tarjeta
+            End If
+
+            BTN_TVenta.Enabled = entregaCliente > 0
+
+            GetVuelto(txt.Text, txtVuelto)
+        Catch ex As Exception
+            MsgError("Error al recalcular el vuelto y validar: " & ex.Message)
+            GetVuelto(0, txtVuelto)
+        End Try
     End Sub
 
     Private Sub GetVuelto(entregaCliente As Decimal, txtVuelto As Guna2TextBox)
@@ -119,37 +141,41 @@ Public Class P_AbonarCxC
     ' "sender" es el botón que ha sido presionado
     Private Sub ColocarTotal(sender As Object, e As EventArgs)
         ' Convierte el objeto sender al tipo de control Guna2Button
-        Dim btn As Guna.UI2.WinForms.Guna2Button = CType(sender, Guna.UI2.WinForms.Guna2Button)
-
+        Dim btn As Guna2Button = CType(sender, Guna2Button)
+        Dim txtEntregaCliente As Guna2TextBox
         ' Usa un Select Case para identificar qué botón se hizo clic y actualizar el TextBox correcto
         Select Case btn.Name
-            Case "BTN_EColocarTotal"
-                NUD_ECliente.Value = venta.Saldo_restante
             Case "BTN_TColocarTotal"
-                NUD_TCliente.Value = venta.Saldo_restante
+                txtEntregaCliente = TXT_TCliente
             Case "BTN_SColocarTotal"
-                NUD_SCliente.Value = venta.Saldo_restante
+                txtEntregaCliente = TXT_SCliente
             Case "BTN_DColocarTotal"
-                NUD_DCliente.Value = venta.Saldo_restante
+                txtEntregaCliente = TXT_DCliente
+            Case Else
+                txtEntregaCliente = TXT_ECliente
         End Select
+
+        txtEntregaCliente.Text = venta.Formated_saldo_restante
     End Sub
 
     ' Calcula el monto restante para pago mixto
-    Private Sub CargarRestante(efectivo As Boolean)
-        Dim restante As Double
-        If efectivo Then ' Si el botón de efectivo restante fue presionado
-            restante = venta.Saldo_restante - NUD_MEfectivo.Value
-            If restante < 0 Then
-                restante = 0
+    Private Sub CargarRestante(fromEfectivo As Boolean)
+        Dim restante As Decimal
+        Dim dineroColocado As Decimal
+        Dim txtMontoActual As Guna2TextBox = If(Not fromEfectivo, TXT_MEfectivo, TXT_MTarjeta)
+        Dim txtCargarRestante As Guna2TextBox = If(fromEfectivo, TXT_MEfectivo, TXT_MTarjeta)
+
+        Try
+            If Not Decimal.TryParse(txtMontoActual.Text, dineroColocado) Then
+                Throw New Exception($"El monto ingresado no es válido. No se puede pasar a Decimal el monto: {txtMontoActual.Text}")
             End If
-            NUD_MTarjeta.Value = restante
-        Else ' Si el botón de tarjeta restante fue presionado
-            restante = venta.Saldo_restante - NUD_MTarjeta.Value
-            If restante < 0 Then
-                restante = 0
-            End If
-            NUD_MEfectivo.Value = restante
-        End If
+
+            restante = venta.Saldo_restante - dineroColocado
+        Catch ex As Exception
+            MsgError("Error al calcular el restante: " & ex.Message)
+        End Try
+
+        txtCargarRestante.Text = If(restante < 0, 0, restante)
     End Sub
 
     'Se agrega el restante al campo correspondiente
@@ -159,13 +185,56 @@ Public Class P_AbonarCxC
         ' Usa un Select Case para identificar qué botón se hizo clic y actualizar el TextBox correcto
         Select Case btn.Name
             Case "BTN_RestanteTarjeta"
-                CargarRestante(True)
-            Case "BTN_RestanteEfectivo"
                 CargarRestante(False)
+            Case "BTN_RestanteEfectivo"
+                CargarRestante(True)
         End Select
-        Dim entregaCliente As Decimal = NUD_MEfectivo.Value + NUD_MTarjeta.Value
+
+        Dim efectivo As Decimal
+        Dim tarjeta As Decimal
+        Dim entregaCliente As Decimal
+
+        Try
+            If Not Decimal.TryParse(TXT_MEfectivo.Text, efectivo) Then
+                Throw New Exception($"El monto en efectivo ingresado no es válido. No se puede pasar a Decimal el monto: {TXT_MEfectivo.Text}")
+            End If
+            If Not Decimal.TryParse(TXT_MTarjeta.Text, tarjeta) Then
+                Throw New Exception($"El monto en tarjeta ingresado no es válido. No se puede pasar a Decimal el monto: {TXT_MTarjeta.Text}")
+            End If
+            entregaCliente = efectivo + tarjeta
+        Catch ex As Exception
+            MsgError("Error al calcular el monto restante: " & ex.Message)
+            entregaCliente = 0
+        End Try
+
         ' Recalcula el vuelto y valida los montos después de agregar el restante
-        getVuelto(entregaCliente, TXT_MVuelto)
+        GetVuelto(entregaCliente, TXT_MVuelto)
+    End Sub
+
+    Private Sub VerifyNumericOnKeyPress(sender As Object, e As KeyPressEventArgs)
+        ' 1. Permitir el uso de teclas de control (como Backspace)
+        If Char.IsControl(e.KeyChar) Then
+            e.Handled = False
+            Exit Sub
+        End If
+
+        ' Obtener el separador decimal de la configuración regional (',' o '.')
+        Dim separadorDecimal As Char = Convert.ToChar(System.Globalization.CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator)
+
+        ' 2. Bloquear cualquier cosa que NO sea un dígito y NO sea el separador decimal.
+        If Not Char.IsDigit(e.KeyChar) AndAlso e.KeyChar <> separadorDecimal Then
+            e.Handled = True ' Bloquear la entrada del carácter
+
+            ' 3. Si es el separador decimal, verificar si ya existe uno en la caja de texto.
+        ElseIf e.KeyChar = separadorDecimal Then
+            Dim txtBox As TextBox = DirectCast(sender, TextBox)
+
+            If txtBox.Text.Contains(separadorDecimal) Then
+                e.Handled = True ' Bloquear si ya existe un separador (solo se permite uno)
+            Else
+                e.Handled = False ' Permitir el separador
+            End If
+        End If
     End Sub
 
     Private Sub BTN_RegresarVenta_Click(sender As Object, e As EventArgs) Handles BTN_RegresarVenta.Click
@@ -174,25 +243,46 @@ Public Class P_AbonarCxC
     End Sub
 
     Private Sub TerminarVenta(imprimir As Boolean)
-        venta.Tipo_pago = TabControlTVenta.SelectedIndex
         Select Case venta.Tipo_pago
             Case 0 ' Efectivo
-                venta.Efectivo = NUD_ECliente.Value
-                venta.Vuelto = Convert.ToDecimal(venta.Vuelto)
-            Case 1 ' Tarjeta
-                venta.Tarjeta = NUD_TCliente.Value
-                venta.Vuelto = Convert.ToDecimal(venta.Vuelto)
-            Case 2 ' Sinpe
-                venta.Tarjeta = NUD_SCliente.Value
-                venta.Vuelto = Convert.ToDecimal(venta.Vuelto)
-            Case 3 ' Depósito
-                venta.Tarjeta = NUD_DCliente.Value
-                venta.Vuelto = Convert.ToDecimal(venta.Vuelto)
+                If Not Decimal.TryParse(TXT_ECliente.Text, venta.Efectivo) Then
+                    MsgError("El monto en efectivo no es válido: " & TXT_ECliente.Text)
+                    Exit Sub
+                End If
+                venta.Tarjeta = 0
+
+            Case 1, 2, 3 ' Tarjeta, Sinpe, Depósito (Se usa el mismo patrón para el monto de la Tarjeta)
+                Dim txtControl As Guna2TextBox = TXT_TCliente
+                Select Case venta.Tipo_pago
+                    Case 2 : txtControl = TXT_SCliente
+                    Case 3 : txtControl = TXT_DCliente
+                End Select
+
+                If Not Decimal.TryParse(txtControl.Text, venta.Tarjeta) Then
+                    MsgError($"El monto de pago (Tipo {venta.Tipo_pago}) no es válido: {txtControl.Text}")
+                    Exit Sub
+                End If
+                venta.Efectivo = 0
+
             Case 4 ' Mixto
-                venta.Efectivo = NUD_MEfectivo.Value
-                venta.Tarjeta = NUD_MTarjeta.Value
-                venta.Vuelto = Convert.ToDecimal(venta.Vuelto)
+                ' 1. Validar Efectivo
+                If Not Decimal.TryParse(TXT_MEfectivo.Text, venta.Efectivo) Then
+                    MsgError("El monto en efectivo para el pago mixto no es válido: " & TXT_MEfectivo.Text)
+                    Exit Sub
+                End If
+
+                ' 2. Validar Tarjeta
+                If Not Decimal.TryParse(TXT_MTarjeta.Text, venta.Tarjeta) Then
+                    MsgError("El monto de tarjeta para el pago mixto no es válido: " & TXT_MTarjeta.Text)
+                    Exit Sub
+                End If
+
+            Case Else
+                ' Manejar cualquier otro caso, si aplica. Por ejemplo:
+                MsgError("Tipo de pago no reconocido.")
+                Exit Sub
         End Select
+
         Terminar_venta = (venta.Efectivo + venta.Tarjeta) >= venta.Saldo_restante
         imprimir_factura = imprimir
         isNavigating = True
@@ -213,6 +303,24 @@ Public Class P_AbonarCxC
                 BTN_RegresarVenta.PerformClick()
             Case Keys.F2
                 BTN_TVenta.PerformClick()
+        End Select
+    End Sub
+
+    Private Sub TabControlTVenta_SelectedIndexChanged(sender As Object, e As EventArgs) Handles TabControlTVenta.SelectedIndexChanged
+        venta.Tipo_pago = TabControlTVenta.SelectedIndex
+        Select Case venta.Tipo_pago
+            Case 0 'efectivo
+                TXT_ECliente.SelectAll()
+                TXT_ECliente.Focus()
+            Case 1
+                TXT_TCliente.SelectAll()
+                TXT_TCliente.Focus()
+            Case 2
+                TXT_SCliente.SelectAll()
+                TXT_SCliente.Focus()
+            Case 3
+                TXT_DCliente.SelectAll()
+                TXT_DCliente.Focus()
         End Select
     End Sub
 End Class

--- a/SistemaFacturación/Forms/CuentasXCobrar/P_CajaCxC.vb
+++ b/SistemaFacturación/Forms/CuentasXCobrar/P_CajaCxC.vb
@@ -380,41 +380,6 @@ Public Class P_CajaCxC
         Me.Close()
     End Sub
 
-    Private Async Sub BTN_TVenta_Click(sender As Object, e As EventArgs)
-        Using endVentaForm As New P_TerminarVenta
-            endVentaForm.Owner = Me
-            If DGV_Caja.Rows.Count < 1 Then
-                Exit Sub
-            End If
-
-            Dim numFactura As Integer = CargarNumFactura()
-            endVentaForm.venta = New Cls_Ventas With {
-                .ID = OBTENERPK("factura", "ID"),
-                .ID_Cliente = Cuenta.ID_Cliente,
-                .ID_Cajero = idUsuActual,
-                .Fecha_creacion = Date.Now,
-                .ListaProductos = prodList,
-                .Saldo_total = Cuenta.Saldo_total,
-                .Num_factura = numFactura,
-                .Tipo_pago = 1,
-                .ID_CxC = idCuenta,
-                .Saldo_restante = Cuenta.Saldo_restante
-            }
-            endVentaForm.isCuentaPorCobrar = True
-
-            'Se pasa el datagrid completo para obtener los datos
-            Dim result As DialogResult = endVentaForm.ShowDialog()
-            If result = DialogResult.Cancel Then
-                Me.DialogResult = DialogResult.Cancel
-                Exit Sub
-            End If
-
-            If Await endVentaForm.venta.GuardarFactura(endVentaForm.imprimir_factura) Then
-                Me.DialogResult = DialogResult.OK
-            End If
-        End Using
-    End Sub
-
     Friend Function CargarNumFactura() As String
         Try
             T.Tables.Clear()
@@ -571,6 +536,11 @@ Public Class P_CajaCxC
                 .Fecha_creacion = Date.Now,
                 .Saldo_restante = Cuenta.Saldo_restante
             }
+
+            abonarForm.TXT_ECliente.Text = Cuenta.Saldo_restante
+            abonarForm.TXT_DCliente.Text = Cuenta.Saldo_restante
+            abonarForm.TXT_SCliente.Text = Cuenta.Saldo_restante
+            abonarForm.TXT_TCliente.Text = Cuenta.Saldo_restante
 
             Dim result As DialogResult = abonarForm.ShowDialog()
 

--- a/SistemaFacturación/Forms/Inicio/M_Inicio.vb
+++ b/SistemaFacturación/Forms/Inicio/M_Inicio.vb
@@ -241,6 +241,7 @@ Namespace SistemaFacturacion.Forms.Inicio
             LBL_Usu.Text = ""
             P_SelectUsu.Show()
             P_SelectUsu.Select()
+            isNavigating = True
             Me.Close()
         End Sub
 

--- a/SistemaFacturación/Forms/Mantenimiento/C_Productos.vb
+++ b/SistemaFacturación/Forms/Mantenimiento/C_Productos.vb
@@ -237,8 +237,10 @@ Namespace SistemaFacturacion.Forms.Mantenimiento
             Dim frmNewProd As New E_NuevoProducto With {
                 .ModProd = False
             }
-            frmNewProd.Show()
-            frmNewProd.Select()
+            frmNewProd.ShowDialog()
+
+            TXT_BuscarProd.SelectAll()
+            TXT_BuscarProd.Focus()
         End Sub
 
         Private Sub BTN_RegresarProd_Click(sender As Object, e As EventArgs) Handles BTN_RegresarProd.Click
@@ -277,6 +279,8 @@ Namespace SistemaFacturacion.Forms.Mantenimiento
 
                 frmNewProd.ShowDialog()
 
+                TXT_BuscarProd.SelectAll()
+                TXT_BuscarProd.Focus()
             Catch ex As Exception
                 MsgError("Error: " & ex.Message)
             End Try

--- a/SistemaFacturación/Forms/Mantenimiento/E_NuevoProducto.vb
+++ b/SistemaFacturación/Forms/Mantenimiento/E_NuevoProducto.vb
@@ -102,6 +102,7 @@ Namespace SistemaFacturacion.Forms.Mantenimiento
                         LIMPIAR()
                         MsgDatoAlm()
                         ModProd = False
+                        isNavigating = True
                         Me.DialogResult = DialogResult.OK
                     Else
                         msgError("Ocurrió un error al guardar los datos. La operación fue revertida.")

--- a/SistemaFacturación/My Project/AssemblyInfo.vb
+++ b/SistemaFacturación/My Project/AssemblyInfo.vb
@@ -28,5 +28,5 @@ Imports System.Runtime.InteropServices
 '      Revisión
 '
 
-<Assembly: AssemblyVersion("3.0.3")>
-<Assembly: AssemblyFileVersion("3.0.3")>
+<Assembly: AssemblyVersion("3.0.4")>
+<Assembly: AssemblyFileVersion("3.0.4")>

--- a/SistemaFacturación/SistemaFacturación.vbproj
+++ b/SistemaFacturación/SistemaFacturación.vbproj
@@ -35,7 +35,7 @@
     <WebPage>publish.htm</WebPage>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>3.0.3.0</ApplicationVersion>
+    <ApplicationVersion>3.0.4.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <CreateDesktopShortcut>true</CreateDesktopShortcut>
     <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
# BugFix
## Abonar o terminar venta
Closes #78 
- Se homogenizaron los procesos de las pestañs de terminar venta para que funcionen de la misma forma  los calculos y las acciones
- Ahora al cambiar de tipo de venta en las pestañas de abonar o terminar venta el texto se selecciona automáticamente para poder cambiarlo sin tener que selecionar el texto completamente de forma manual
- Ahora al entrar a las pestañas de abonar o terminar venta se coloca automáticamente el monto total de la venta para simplemente presionar el botón de terminar venta o f7 en ese caso