### PR TITLE
Fix de problemas en reportes

### DIFF
--- a/HISTORICRELREASENOTES.md
+++ b/HISTORICRELREASENOTES.md
@@ -1,3 +1,16 @@
+# Notas del parche versión 3.0.10 (29 de ene de 2026)
+
+Esta actualización busca resolver algunos problemas identificados en la sección de reportes y algunas mejoras en la calidad de vida
+
+## Nuevo
+- Se agregó un botón en las secciones de reportes que permite colocar de forma automátca los datos del día actual en los campos del rango de fechas.
+- Ahora, por defecto, en los reportes de productos el valor por defecto del campo "Cantidad" pasó de 1 a 10, esto para mostrar por defecto los 10 productos más vendidos ya que el valor anterior no tenía sentido práctico
+
+## Bugfix
+- Se arregló un error en el que al intentar descargar el pdf de un reporte que tuviera cualquier fecha que no fuera la del día actual provocaba que este se creara en blanco
+- Se arregló un error en el que el límite superior del rango de las fechas en los reportes no estaban funcionan correctamente en algunos casos
+- Se mejoró el estilado de la tabla donde se muestran los reportes de ventas, la cual ahora se adapta de mejor manera dependiendo del tamaño de la pantalla
+
 # Notas del parche versión 3.0.8 (5}8 de ene de 2026)
 
 Esta actualización busca resolver algunos problemas identificados en el flujo de trabajo de los arqueos de caja y problemas entre las sesiones y algunas otras cosas.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,12 +1,12 @@
-# Notas del parche versión 3.0.8 (5}8 de ene de 2026)
+# Notas del parche versión 3.0.10 (29 de ene de 2026)
 
-Esta actualización busca resolver algunos problemas identificados en el flujo de trabajo de los arqueos de caja y problemas entre las sesiones y algunas otras cosas.
+Esta actualización busca resolver algunos problemas identificados en la sección de reportes y algunas mejoras en la calidad de vida
 
-## BugFix
+## Nuevo
+- Se agregó un botón en las secciones de reportes que permite colocar de forma automátca los datos del día actual en los campos del rango de fechas.
+- Ahora, por defecto, en los reportes de productos el valor por defecto del campo "Cantidad" pasó de 1 a 10, esto para mostrar por defecto los 10 productos más vendidos ya que el valor anterior no tenía sentido práctico
 
-- Se arregló un error por el que al terminar turno en una cuenta, el turno aparecía como terminado en las demás cuentas.
-- Se arregló un error en el que al hacer el cierre no aparecía la información correspondiente a las ventas de esa fecha.
-- Ahora se detecta correctamente de forma individual por cada usuario si ya ha iniciado o no su turno
-- Se arregló un erro en el que al interar en una cuenta de cajero su id de sesión no era correctamente enviado y utilizado alrededor de la aplicación haciendo que algunas ventas se guardaran con valores en 0
-- Mejoras de estabilidad y disminución del tamaño de la aplicación eliminando archivos innecesarios
-- Se arregló un error en ciertos tipos de reportes y obtenciones de listas de ventas en el que por problemas en el formato de la fecha esta no mostraba la información correcta
+## Bugfix
+- Se arregló un error en el que al intentar descargar el pdf de un reporte que tuviera cualquier fecha que no fuera la del día actual provocaba que este se creara en blanco
+- Se arregló un error en el que el límite superior del rango de las fechas en los reportes no estaban funcionan correctamente en algunos casos
+- Se mejoró el estilado de la tabla donde se muestran los reportes de ventas, la cual ahora se adapta de mejor manera dependiendo del tamaño de la pantalla

--- a/SistemaFacturación/Data/Cls_DatosFactura.vb
+++ b/SistemaFacturación/Data/Cls_DatosFactura.vb
@@ -5,12 +5,12 @@
         Public Property Fecha As String
         Public Property Cliente As String
         Public Property Cajero As String
+        Public Property TipoPago As String
         Public Property Efectivo As String
         Public Property Tarjeta As String
         Public Property Vuelto As String
-        Public Property TipoPago As String
-        Public Property Comentario As String
         Public Property TotalCaja As Decimal
+        Public Property Comentario As String
     End Class
 
 

--- a/SistemaFacturación/Forms/Reportes/P_ReporteVentas.Designer.vb
+++ b/SistemaFacturación/Forms/Reportes/P_ReporteVentas.Designer.vb
@@ -113,6 +113,8 @@
             Me.DGV_ListaCierres = New Guna.UI2.WinForms.Guna2DataGridView()
             Me.MNU_CONTX_ARQUEO = New Guna.UI2.WinForms.Guna2ContextMenuStrip()
             Me.MNU_ARQUEO_DATOS = New System.Windows.Forms.ToolStripMenuItem()
+            Me.BTN_TodayRepGeneral = New Guna.UI2.WinForms.Guna2Button()
+            Me.BTN_TodayRepProd = New Guna.UI2.WinForms.Guna2Button()
             Me.TAB_Reportes.SuspendLayout()
             Me.PAG_ReporteVentas.SuspendLayout()
             Me.TableLayoutPanel1.SuspendLayout()
@@ -176,6 +178,7 @@
             'PAG_ReporteVentas
             '
             Me.PAG_ReporteVentas.BackColor = System.Drawing.Color.FromArgb(CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer), CType(CType(38, Byte), Integer))
+            Me.PAG_ReporteVentas.Controls.Add(Me.BTN_TodayRepGeneral)
             Me.PAG_ReporteVentas.Controls.Add(Me.DTP_HoraFinalRepVentas)
             Me.PAG_ReporteVentas.Controls.Add(Me.DTP_HoraInicioRepVentas)
             Me.PAG_ReporteVentas.Controls.Add(Me.TableLayoutPanel1)
@@ -203,7 +206,7 @@
             Me.DTP_HoraFinalRepVentas.FillColor = System.Drawing.Color.White
             Me.DTP_HoraFinalRepVentas.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_HoraFinalRepVentas.Format = System.Windows.Forms.DateTimePickerFormat.Custom
-            Me.DTP_HoraFinalRepVentas.Location = New System.Drawing.Point(937, 524)
+            Me.DTP_HoraFinalRepVentas.Location = New System.Drawing.Point(938, 574)
             Me.DTP_HoraFinalRepVentas.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_HoraFinalRepVentas.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_HoraFinalRepVentas.Name = "DTP_HoraFinalRepVentas"
@@ -221,7 +224,7 @@
             Me.DTP_HoraInicioRepVentas.FillColor = System.Drawing.Color.White
             Me.DTP_HoraInicioRepVentas.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_HoraInicioRepVentas.Format = System.Windows.Forms.DateTimePickerFormat.Custom
-            Me.DTP_HoraInicioRepVentas.Location = New System.Drawing.Point(938, 405)
+            Me.DTP_HoraInicioRepVentas.Location = New System.Drawing.Point(939, 455)
             Me.DTP_HoraInicioRepVentas.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_HoraInicioRepVentas.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_HoraInicioRepVentas.Name = "DTP_HoraInicioRepVentas"
@@ -520,7 +523,7 @@
             Me.Guna2HtmlLabel1.BackColor = System.Drawing.Color.Transparent
             Me.Guna2HtmlLabel1.Font = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Guna2HtmlLabel1.ForeColor = System.Drawing.SystemColors.Control
-            Me.Guna2HtmlLabel1.Location = New System.Drawing.Point(937, 453)
+            Me.Guna2HtmlLabel1.Location = New System.Drawing.Point(938, 503)
             Me.Guna2HtmlLabel1.Name = "Guna2HtmlLabel1"
             Me.Guna2HtmlLabel1.Size = New System.Drawing.Size(50, 23)
             Me.Guna2HtmlLabel1.TabIndex = 127
@@ -533,7 +536,7 @@
             Me.LBL_Usu.BackColor = System.Drawing.Color.Transparent
             Me.LBL_Usu.Font = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.LBL_Usu.ForeColor = System.Drawing.SystemColors.Control
-            Me.LBL_Usu.Location = New System.Drawing.Point(937, 334)
+            Me.LBL_Usu.Location = New System.Drawing.Point(938, 384)
             Me.LBL_Usu.Name = "LBL_Usu"
             Me.LBL_Usu.Size = New System.Drawing.Size(54, 23)
             Me.LBL_Usu.TabIndex = 126
@@ -640,7 +643,7 @@
             Me.DTP_HastaRepVentas.FillColor = System.Drawing.Color.White
             Me.DTP_HastaRepVentas.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_HastaRepVentas.Format = System.Windows.Forms.DateTimePickerFormat.Custom
-            Me.DTP_HastaRepVentas.Location = New System.Drawing.Point(937, 482)
+            Me.DTP_HastaRepVentas.Location = New System.Drawing.Point(938, 532)
             Me.DTP_HastaRepVentas.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_HastaRepVentas.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_HastaRepVentas.Name = "DTP_HastaRepVentas"
@@ -657,7 +660,7 @@
             Me.DTP_DesdeRepVentas.FillColor = System.Drawing.Color.White
             Me.DTP_DesdeRepVentas.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_DesdeRepVentas.Format = System.Windows.Forms.DateTimePickerFormat.Custom
-            Me.DTP_DesdeRepVentas.Location = New System.Drawing.Point(937, 363)
+            Me.DTP_DesdeRepVentas.Location = New System.Drawing.Point(938, 413)
             Me.DTP_DesdeRepVentas.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_DesdeRepVentas.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_DesdeRepVentas.Name = "DTP_DesdeRepVentas"
@@ -1052,6 +1055,7 @@
             '
             'PAN_ReporteProductoInputContainer
             '
+            Me.PAN_ReporteProductoInputContainer.Controls.Add(Me.BTN_TodayRepProd)
             Me.PAN_ReporteProductoInputContainer.Controls.Add(Me.DTP_HoraFinRepProducto)
             Me.PAN_ReporteProductoInputContainer.Controls.Add(Me.DTP_HoraInicioRepProducto)
             Me.PAN_ReporteProductoInputContainer.Controls.Add(Me.Guna2GroupBox3)
@@ -1079,7 +1083,7 @@
             Me.DTP_HoraFinRepProducto.FillColor = System.Drawing.Color.White
             Me.DTP_HoraFinRepProducto.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_HoraFinRepProducto.Format = System.Windows.Forms.DateTimePickerFormat.Custom
-            Me.DTP_HoraFinRepProducto.Location = New System.Drawing.Point(55, 419)
+            Me.DTP_HoraFinRepProducto.Location = New System.Drawing.Point(55, 450)
             Me.DTP_HoraFinRepProducto.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_HoraFinRepProducto.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_HoraFinRepProducto.Name = "DTP_HoraFinRepProducto"
@@ -1090,14 +1094,15 @@
             '
             'DTP_HoraInicioRepProducto
             '
-            Me.DTP_HoraInicioRepProducto.Anchor = CType((System.Windows.Forms.AnchorStyles.Left Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.DTP_HoraInicioRepProducto.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
             Me.DTP_HoraInicioRepProducto.BorderRadius = 10
             Me.DTP_HoraInicioRepProducto.Checked = True
             Me.DTP_HoraInicioRepProducto.CustomFormat = "hh:mm tt"
             Me.DTP_HoraInicioRepProducto.FillColor = System.Drawing.Color.White
             Me.DTP_HoraInicioRepProducto.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_HoraInicioRepProducto.Format = System.Windows.Forms.DateTimePickerFormat.Custom
-            Me.DTP_HoraInicioRepProducto.Location = New System.Drawing.Point(55, 306)
+            Me.DTP_HoraInicioRepProducto.Location = New System.Drawing.Point(55, 337)
             Me.DTP_HoraInicioRepProducto.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_HoraInicioRepProducto.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_HoraInicioRepProducto.Name = "DTP_HoraInicioRepProducto"
@@ -1118,7 +1123,7 @@
             Me.Guna2GroupBox3.FillColor = System.Drawing.Color.Transparent
             Me.Guna2GroupBox3.Font = New System.Drawing.Font("Segoe UI", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Guna2GroupBox3.ForeColor = System.Drawing.Color.White
-            Me.Guna2GroupBox3.Location = New System.Drawing.Point(55, 469)
+            Me.Guna2GroupBox3.Location = New System.Drawing.Point(55, 500)
             Me.Guna2GroupBox3.Name = "Guna2GroupBox3"
             Me.Guna2GroupBox3.Padding = New System.Windows.Forms.Padding(10, 10, 10, 5)
             Me.Guna2GroupBox3.Size = New System.Drawing.Size(282, 114)
@@ -1161,7 +1166,7 @@
             Me.Guna2HtmlLabel15.BackColor = System.Drawing.Color.Transparent
             Me.Guna2HtmlLabel15.Font = New System.Drawing.Font("Segoe UI", 18.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Guna2HtmlLabel15.ForeColor = System.Drawing.SystemColors.Control
-            Me.Guna2HtmlLabel15.Location = New System.Drawing.Point(65, 43)
+            Me.Guna2HtmlLabel15.Location = New System.Drawing.Point(65, 19)
             Me.Guna2HtmlLabel15.Name = "Guna2HtmlLabel15"
             Me.Guna2HtmlLabel15.Size = New System.Drawing.Size(272, 34)
             Me.Guna2HtmlLabel15.TabIndex = 151
@@ -1197,7 +1202,7 @@
             Me.Guna2HtmlLabel13.BackColor = System.Drawing.Color.Transparent
             Me.Guna2HtmlLabel13.Font = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Guna2HtmlLabel13.ForeColor = System.Drawing.SystemColors.Control
-            Me.Guna2HtmlLabel13.Location = New System.Drawing.Point(55, 348)
+            Me.Guna2HtmlLabel13.Location = New System.Drawing.Point(55, 379)
             Me.Guna2HtmlLabel13.Name = "Guna2HtmlLabel13"
             Me.Guna2HtmlLabel13.Size = New System.Drawing.Size(50, 23)
             Me.Guna2HtmlLabel13.TabIndex = 149
@@ -1206,11 +1211,12 @@
             '
             'Guna2HtmlLabel14
             '
-            Me.Guna2HtmlLabel14.Anchor = CType((System.Windows.Forms.AnchorStyles.Left Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.Guna2HtmlLabel14.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
             Me.Guna2HtmlLabel14.BackColor = System.Drawing.Color.Transparent
             Me.Guna2HtmlLabel14.Font = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Guna2HtmlLabel14.ForeColor = System.Drawing.SystemColors.Control
-            Me.Guna2HtmlLabel14.Location = New System.Drawing.Point(55, 238)
+            Me.Guna2HtmlLabel14.Location = New System.Drawing.Point(55, 269)
             Me.Guna2HtmlLabel14.Name = "Guna2HtmlLabel14"
             Me.Guna2HtmlLabel14.Size = New System.Drawing.Size(54, 23)
             Me.Guna2HtmlLabel14.TabIndex = 148
@@ -1227,7 +1233,7 @@
             Me.DTP_HastaRepProducto.FillColor = System.Drawing.Color.White
             Me.DTP_HastaRepProducto.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_HastaRepProducto.Format = System.Windows.Forms.DateTimePickerFormat.Custom
-            Me.DTP_HastaRepProducto.Location = New System.Drawing.Point(55, 377)
+            Me.DTP_HastaRepProducto.Location = New System.Drawing.Point(55, 408)
             Me.DTP_HastaRepProducto.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_HastaRepProducto.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_HastaRepProducto.Name = "DTP_HastaRepProducto"
@@ -1237,14 +1243,15 @@
             '
             'DTP_DesdeRepProducto
             '
-            Me.DTP_DesdeRepProducto.Anchor = CType((System.Windows.Forms.AnchorStyles.Left Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.DTP_DesdeRepProducto.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
             Me.DTP_DesdeRepProducto.BorderRadius = 10
             Me.DTP_DesdeRepProducto.Checked = True
             Me.DTP_DesdeRepProducto.CustomFormat = "dd/MM/yyyy"
             Me.DTP_DesdeRepProducto.FillColor = System.Drawing.Color.White
             Me.DTP_DesdeRepProducto.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_DesdeRepProducto.Format = System.Windows.Forms.DateTimePickerFormat.Custom
-            Me.DTP_DesdeRepProducto.Location = New System.Drawing.Point(55, 267)
+            Me.DTP_DesdeRepProducto.Location = New System.Drawing.Point(55, 298)
             Me.DTP_DesdeRepProducto.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_DesdeRepProducto.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_DesdeRepProducto.Name = "DTP_DesdeRepProducto"
@@ -1254,29 +1261,29 @@
             '
             'NUD_LimitReporteProducto
             '
-            Me.NUD_LimitReporteProducto.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Me.NUD_LimitReporteProducto.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
             Me.NUD_LimitReporteProducto.BackColor = System.Drawing.Color.Transparent
             Me.NUD_LimitReporteProducto.BorderRadius = 10
             Me.NUD_LimitReporteProducto.Cursor = System.Windows.Forms.Cursors.IBeam
             Me.NUD_LimitReporteProducto.Font = New System.Drawing.Font("Segoe UI", 9.0!)
-            Me.NUD_LimitReporteProducto.Location = New System.Drawing.Point(55, 157)
+            Me.NUD_LimitReporteProducto.Location = New System.Drawing.Point(55, 166)
             Me.NUD_LimitReporteProducto.Maximum = New Decimal(New Integer() {10000, 0, 0, 0})
             Me.NUD_LimitReporteProducto.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
             Me.NUD_LimitReporteProducto.Name = "NUD_LimitReporteProducto"
             Me.NUD_LimitReporteProducto.Size = New System.Drawing.Size(282, 36)
             Me.NUD_LimitReporteProducto.TabIndex = 145
             Me.NUD_LimitReporteProducto.UpDownButtonFillColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(0, Byte), Integer))
-            Me.NUD_LimitReporteProducto.Value = New Decimal(New Integer() {1, 0, 0, 0})
+            Me.NUD_LimitReporteProducto.Value = New Decimal(New Integer() {10, 0, 0, 0})
             '
             'Guna2HtmlLabel12
             '
-            Me.Guna2HtmlLabel12.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Me.Guna2HtmlLabel12.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
             Me.Guna2HtmlLabel12.BackColor = System.Drawing.Color.Transparent
             Me.Guna2HtmlLabel12.Font = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Bold)
             Me.Guna2HtmlLabel12.ForeColor = System.Drawing.SystemColors.Control
-            Me.Guna2HtmlLabel12.Location = New System.Drawing.Point(55, 128)
+            Me.Guna2HtmlLabel12.Location = New System.Drawing.Point(55, 137)
             Me.Guna2HtmlLabel12.Name = "Guna2HtmlLabel12"
             Me.Guna2HtmlLabel12.Size = New System.Drawing.Size(152, 23)
             Me.Guna2HtmlLabel12.TabIndex = 143
@@ -1336,7 +1343,7 @@
             Me.TBL_LayoutSearch.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 80.50459!))
             Me.TBL_LayoutSearch.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 109.0!))
             Me.TBL_LayoutSearch.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 299.0!))
-            Me.TBL_LayoutSearch.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 120.0!))
+            Me.TBL_LayoutSearch.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 122.0!))
             Me.TBL_LayoutSearch.Controls.Add(Me.DTP_FechaFiltroArqueo, 3, 0)
             Me.TBL_LayoutSearch.Controls.Add(Me.Guna2HtmlLabel17, 2, 0)
             Me.TBL_LayoutSearch.Controls.Add(Me.Guna2HtmlLabel18, 0, 0)
@@ -1358,7 +1365,7 @@
             Me.DTP_FechaFiltroArqueo.FillColor = System.Drawing.Color.White
             Me.DTP_FechaFiltroArqueo.Font = New System.Drawing.Font("Segoe UI", 9.0!)
             Me.DTP_FechaFiltroArqueo.Format = System.Windows.Forms.DateTimePickerFormat.[Long]
-            Me.DTP_FechaFiltroArqueo.Location = New System.Drawing.Point(817, 3)
+            Me.DTP_FechaFiltroArqueo.Location = New System.Drawing.Point(815, 3)
             Me.DTP_FechaFiltroArqueo.MaxDate = New Date(9998, 12, 31, 0, 0, 0, 0)
             Me.DTP_FechaFiltroArqueo.MinDate = New Date(1753, 1, 1, 0, 0, 0, 0)
             Me.DTP_FechaFiltroArqueo.Name = "DTP_FechaFiltroArqueo"
@@ -1373,7 +1380,7 @@
             Me.Guna2HtmlLabel17.Dock = System.Windows.Forms.DockStyle.Fill
             Me.Guna2HtmlLabel17.Font = New System.Drawing.Font("Segoe UI", 15.75!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
             Me.Guna2HtmlLabel17.ForeColor = System.Drawing.SystemColors.Control
-            Me.Guna2HtmlLabel17.Location = New System.Drawing.Point(708, 3)
+            Me.Guna2HtmlLabel17.Location = New System.Drawing.Point(706, 3)
             Me.Guna2HtmlLabel17.Name = "Guna2HtmlLabel17"
             Me.Guna2HtmlLabel17.Size = New System.Drawing.Size(103, 48)
             Me.Guna2HtmlLabel17.TabIndex = 156
@@ -1415,14 +1422,14 @@
             Me.TXT_BuscarUsuario.Name = "TXT_BuscarUsuario"
             Me.TXT_BuscarUsuario.PlaceholderText = ""
             Me.TXT_BuscarUsuario.SelectedText = ""
-            Me.TXT_BuscarUsuario.Size = New System.Drawing.Size(562, 48)
+            Me.TXT_BuscarUsuario.Size = New System.Drawing.Size(560, 48)
             Me.TXT_BuscarUsuario.TabIndex = 155
             '
             'PAN_SWTBuscarFecha
             '
             Me.PAN_SWTBuscarFecha.Controls.Add(Me.SWT_ActivateDateSearch)
             Me.PAN_SWTBuscarFecha.Controls.Add(Me.Guna2HtmlLabel19)
-            Me.PAN_SWTBuscarFecha.Location = New System.Drawing.Point(1116, 3)
+            Me.PAN_SWTBuscarFecha.Location = New System.Drawing.Point(1114, 3)
             Me.PAN_SWTBuscarFecha.Name = "PAN_SWTBuscarFecha"
             Me.PAN_SWTBuscarFecha.Size = New System.Drawing.Size(106, 48)
             Me.PAN_SWTBuscarFecha.TabIndex = 158
@@ -1596,6 +1603,48 @@
             Me.MNU_ARQUEO_DATOS.Size = New System.Drawing.Size(136, 26)
             Me.MNU_ARQUEO_DATOS.Text = "Ver datos"
             '
+            'BTN_TodayRepGeneral
+            '
+            Me.BTN_TodayRepGeneral.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.BTN_TodayRepGeneral.BorderColor = System.Drawing.Color.Red
+            Me.BTN_TodayRepGeneral.BorderRadius = 10
+            Me.BTN_TodayRepGeneral.DisabledState.BorderColor = System.Drawing.Color.DarkGray
+            Me.BTN_TodayRepGeneral.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
+            Me.BTN_TodayRepGeneral.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
+            Me.BTN_TodayRepGeneral.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
+            Me.BTN_TodayRepGeneral.FillColor = System.Drawing.Color.FromArgb(CType(CType(128, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.BTN_TodayRepGeneral.Font = New System.Drawing.Font("Ebrima", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.BTN_TodayRepGeneral.ForeColor = System.Drawing.Color.White
+            Me.BTN_TodayRepGeneral.HoverState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(94, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.BTN_TodayRepGeneral.ImageSize = New System.Drawing.Size(50, 50)
+            Me.BTN_TodayRepGeneral.Location = New System.Drawing.Point(938, 340)
+            Me.BTN_TodayRepGeneral.Name = "BTN_TodayRepGeneral"
+            Me.BTN_TodayRepGeneral.PressedColor = System.Drawing.Color.FromArgb(CType(CType(0, Byte), Integer), CType(CType(0, Byte), Integer), CType(CType(64, Byte), Integer))
+            Me.BTN_TodayRepGeneral.Size = New System.Drawing.Size(118, 38)
+            Me.BTN_TodayRepGeneral.TabIndex = 142
+            Me.BTN_TodayRepGeneral.Text = "Hoy"
+            '
+            'BTN_TodayRepProd
+            '
+            Me.BTN_TodayRepProd.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+            Me.BTN_TodayRepProd.BorderColor = System.Drawing.Color.Red
+            Me.BTN_TodayRepProd.BorderRadius = 10
+            Me.BTN_TodayRepProd.DisabledState.BorderColor = System.Drawing.Color.DarkGray
+            Me.BTN_TodayRepProd.DisabledState.CustomBorderColor = System.Drawing.Color.DarkGray
+            Me.BTN_TodayRepProd.DisabledState.FillColor = System.Drawing.Color.FromArgb(CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer), CType(CType(169, Byte), Integer))
+            Me.BTN_TodayRepProd.DisabledState.ForeColor = System.Drawing.Color.FromArgb(CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer), CType(CType(141, Byte), Integer))
+            Me.BTN_TodayRepProd.FillColor = System.Drawing.Color.FromArgb(CType(CType(128, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.BTN_TodayRepProd.Font = New System.Drawing.Font("Ebrima", 14.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+            Me.BTN_TodayRepProd.ForeColor = System.Drawing.Color.White
+            Me.BTN_TodayRepProd.HoverState.FillColor = System.Drawing.Color.FromArgb(CType(CType(94, Byte), Integer), CType(CType(94, Byte), Integer), CType(CType(255, Byte), Integer))
+            Me.BTN_TodayRepProd.ImageSize = New System.Drawing.Size(50, 50)
+            Me.BTN_TodayRepProd.Location = New System.Drawing.Point(55, 225)
+            Me.BTN_TodayRepProd.Name = "BTN_TodayRepProd"
+            Me.BTN_TodayRepProd.PressedColor = System.Drawing.Color.FromArgb(CType(CType(0, Byte), Integer), CType(CType(0, Byte), Integer), CType(CType(64, Byte), Integer))
+            Me.BTN_TodayRepProd.Size = New System.Drawing.Size(118, 38)
+            Me.BTN_TodayRepProd.TabIndex = 155
+            Me.BTN_TodayRepProd.Text = "Hoy"
+            '
             'P_ReporteVentas
             '
             Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -1720,6 +1769,8 @@
         Friend WithEvents DTP_HoraFinalRepVentas As Guna.UI2.WinForms.Guna2DateTimePicker
         Friend WithEvents DTP_HoraFinRepProducto As Guna.UI2.WinForms.Guna2DateTimePicker
         Friend WithEvents DTP_HoraInicioRepProducto As Guna.UI2.WinForms.Guna2DateTimePicker
+        Friend WithEvents BTN_TodayRepGeneral As Guna.UI2.WinForms.Guna2Button
+        Friend WithEvents BTN_TodayRepProd As Guna.UI2.WinForms.Guna2Button
     End Class
 
 End Namespace

--- a/SistemaFacturación/Forms/Reportes/P_ReporteVentas.vb
+++ b/SistemaFacturación/Forms/Reportes/P_ReporteVentas.vb
@@ -1,11 +1,13 @@
 ﻿Imports System.Data.SQLite
 Imports System.Globalization
 Imports Guna.UI2.WinForms
+Imports Serilog
 Imports SistemaFacturaciónCommon.SistemaFacturacion.Data
 Imports SistemaFacturaciónCommon.SistemaFacturacion.Forms.Caja
 Imports SistemaFacturaciónCommon.SistemaFacturacion.Forms.Dialogos
 Imports SistemaFacturaciónCommon.SistemaFacturacion.Forms.Inicio
 Imports SistemaFacturaciónCommon.SistemaFacturacion.Modules
+Imports SistemaFacturaciónCommon.SistemaFacturacion.Modules.Md_formating
 
 
 Namespace SistemaFacturacion.Forms.Reportes
@@ -44,7 +46,7 @@ Namespace SistemaFacturacion.Forms.Reportes
                 Case "PAG_ReporteVentas"
                     ' Lógica para cargar los datos de la pestaña de Ventas.
                     'Se carga la fecha actual
-                    CargarFechaActual()
+                    EstablecerFechaActual()
                     'Se aplican los estilos a los Data grid view
                     AplicarEstiloDataGridView(DGV_FactReporte)
 
@@ -54,7 +56,7 @@ Namespace SistemaFacturacion.Forms.Reportes
                 Case "PAG_ReporteProd"
                     ' Lógica para cargar los datos de la pestaña de Reportes.
                     'Se carga la fecha actual
-                    CargarFechaActual()
+                    EstablecerFechaActual()
                     AplicarEstiloDataGridView(DGV_ListProductosMasVendidos)
                     RDB_OrderByCant.Checked = True
 
@@ -72,21 +74,21 @@ Namespace SistemaFacturacion.Forms.Reportes
             Me.Close()
         End Sub
 
-        Private Sub CargarFechaActual()
-            ' Establece la fecha de inicio al inicio del día (00:00:00)
-            DTP_DesdeRepVentas.Value = Date.Now.Date
-            DTP_HoraInicioRepVentas.Value = Date.Now.Date
-
-            ' Establece la fecha de fin al final del día (23:59:59)
-            DTP_HastaRepVentas.Value = Date.Now.Date.AddDays(1)
-            DTP_HoraFinalRepVentas.Value = Date.Now.Date.AddDays(1).AddTicks(-1)
-
-            ' Se aplica la misma lógica
-            DTP_DesdeRepProducto.Value = Date.Now.Date
-            DTP_HoraInicioRepProducto.Value = Date.Now.Date
-            DTP_HastaRepProducto.Value = Date.Now.Date.AddDays(1).AddTicks(-1)
-            DTP_HoraFinRepProducto.Value = Date.Now.Date.AddDays(1).AddTicks(-1)
+        Private Sub EstablecerFechaActual()
+            Select Case TAB_Reportes.SelectedTab.Name
+                Case "PAG_ReporteVentas"
+                    DTP_DesdeRepVentas.Value = Date.Now.Date
+                    DTP_HoraInicioRepVentas.Value = Date.Now.Date
+                    DTP_HastaRepVentas.Value = Date.Now.Date
+                    DTP_HoraFinalRepVentas.Value = Date.Now.Date.AddDays(1).AddSeconds(-1)
+                Case "PAG_ReporteProd"
+                    DTP_DesdeRepProducto.Value = Date.Now.Date
+                    DTP_HoraInicioRepProducto.Value = Date.Now.Date
+                    DTP_HastaRepProducto.Value = Date.Now.Date
+                    DTP_HoraFinRepProducto.Value = Date.Now.Date.AddDays(1).AddSeconds(-1)
+            End Select
         End Sub
+
 
         ' Este método puede estar en un módulo o en tu clase del formulario
         Private Sub AplicarEstiloDataGridView(ByVal dgv As Guna.UI2.WinForms.Guna2DataGridView)
@@ -155,11 +157,7 @@ Namespace SistemaFacturacion.Forms.Reportes
         Friend facturaContenido As New List(Of String)()
         Friend finFactura As String
 
-        Private Sub BTN_GenReporte_Click(sender As Object, e As EventArgs) Handles BTN_GenReporte.Click
-            MostrarReporteVentas()
-        End Sub
-
-        Private Async Sub MostrarReporteVentas()
+        Private Async Sub BTN_GenReporte_Click(sender As Object, e As EventArgs) Handles BTN_GenReporte.Click
             Try
                 'Se desabilta el botón durante la creación del reporte
                 BTN_GenReporte.Enabled = False
@@ -181,16 +179,14 @@ Namespace SistemaFacturacion.Forms.Reportes
                 Dim bin As New BindingSource With {
                     .DataSource = reporte.ListaVentas
                 }
-                DGV_FactReporte.AutoGenerateColumns = True
                 DGV_FactReporte.DataSource = bin
-                DGV_FactReporte.Columns(0).Visible = False
 
                 'Se agrega el total de ventas global
-                TXT_TotalVentas.Text = reporte.total_ventas.ToString("C", New CultureInfo("es-CR"))
+                TXT_TotalVentas.Text = reporte.total_ventas.ToString("C", CrCultureInfo)
 
                 'Se agrega el total de ventas en efectivo y en tarjeta
-                TXT_VentasEfectivo.Text = reporte.ventas_efectivo.ToString("C", New CultureInfo("es-CR"))
-                TXT_VentasTarjeta.Text = reporte.ventas_tarjeta.ToString("C", New CultureInfo("es-CR"))
+                TXT_VentasEfectivo.Text = reporte.ventas_efectivo.ToString("C", CrCultureInfo)
+                TXT_VentasTarjeta.Text = reporte.ventas_tarjeta.ToString("C", CrCultureInfo)
 
                 'Se agrega el número de ventas en el rango
                 TXT_CantFacturas.Text = reporte.num_ventas.ToString("N0")
@@ -199,7 +195,7 @@ Namespace SistemaFacturacion.Forms.Reportes
                 If reporte.ProductoMasVendido IsNot Nothing Then
                     TXT_NombreProdMasVendido.Text = reporte.ProductoMasVendido.Nombre
                     TXT_CantProdMasVendido.Text = reporte.ProductoMasVendido.Cantidad.ToString("N0")
-                    TXT_TotalProdMasVendido.Text = reporte.ProductoMasVendido.Total.ToString("C", New CultureInfo("es-CR"))
+                    TXT_TotalProdMasVendido.Text = reporte.ProductoMasVendido.Total.ToString("C", CrCultureInfo)
                 Else
                     TXT_NombreProdMasVendido.Text = "Sin datos"
                     TXT_CantProdMasVendido.Text = "Sin datos"
@@ -212,6 +208,45 @@ Namespace SistemaFacturacion.Forms.Reportes
                 BTN_GenReporte.BackColor = Color.FromKnownColor(KnownColor.MediumSeaGreen)
             Catch ex As Exception
                 MsgError("Error al crear el reporte: " + ex.Message)
+            End Try
+        End Sub
+
+
+        Private Sub DGV_FactReporte_DataBindingComplete(sender As Object, e As DataGridViewBindingCompleteEventArgs) Handles DGV_FactReporte.DataBindingComplete
+            Try
+                If DGV_FactReporte.Columns Is Nothing OrElse DGV_FactReporte.Columns.Count = 0 Then
+                    Log.Warning("No se encontraron las columnas del datagrid")
+                    Return
+                End If
+
+                Dim anchoPantalla As Integer = Screen.FromControl(Me).WorkingArea.Width
+
+                With DGV_FactReporte
+                    .AutoGenerateColumns = True
+                    .AutoSizeColumnsMode = If(anchoPantalla > 1366,
+                                                DataGridViewAutoSizeColumnsMode.Fill,
+                                                DataGridViewAutoSizeColumnsMode.DisplayedCells)
+
+                    'Oculta la columna de ID
+                    .Columns("IdFactura").Visible = False
+                    'Cambia el nombre de las columnas
+                    .Columns("NumFactura").HeaderText = "#"
+                    .Columns("TipoPago").HeaderText = "Tipo"
+                    .Columns("TotalCaja").HeaderText = "Total"
+                    'Adapta el tamaño de columnas específicas
+                    If anchoPantalla <= 768 Then
+                        .Columns("Comentario").AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
+                    End If
+                    'Formatea las columnas de totales a moneda de Costa Rica
+                    .Columns("Efectivo").DefaultCellStyle.Format = "C"
+                    .Columns("Efectivo").DefaultCellStyle.FormatProvider = CrCultureInfo
+                    .Columns("Tarjeta").DefaultCellStyle.Format = "C"
+                    .Columns("Tarjeta").DefaultCellStyle.FormatProvider = CrCultureInfo
+                    .Columns("Vuelto").DefaultCellStyle.Format = "C"
+                    .Columns("Vuelto").DefaultCellStyle.FormatProvider = CrCultureInfo
+                End With
+            Catch ex As Exception
+
             End Try
         End Sub
 
@@ -250,8 +285,12 @@ Namespace SistemaFacturacion.Forms.Reportes
                 'Se genera el reporte desde el módulo de reportes
                 Dim fechaInicial As Date = DTP_DesdeRepVentas.Value.Date.Add(DTP_HoraInicioRepVentas.Value.TimeOfDay)
                 Dim fechaFinal As Date = DTP_HastaRepVentas.Value.Date.Add(DTP_HoraFinalRepVentas.Value.TimeOfDay)
-                Md_Reportes.Crear_PDF_ReporteVentas(DTP_DesdeRepVentas.Value, DTP_HastaRepVentas.Value)
+                Md_Reportes.Crear_PDF_ReporteVentas(fechaInicial, fechaFinal)
             End If
+        End Sub
+
+        Private Sub BTN_SelectToday_Click(sender As Object, e As EventArgs) Handles BTN_TodayRepGeneral.Click
+            EstablecerFechaActual()
         End Sub
 
 #End Region
@@ -342,11 +381,18 @@ Namespace SistemaFacturacion.Forms.Reportes
 
         Private Sub DGV_ListProductosMasVendidos_DataBindingComplete(sender As Object, e As DataGridViewBindingCompleteEventArgs) Handles DGV_ListProductosMasVendidos.DataBindingComplete
             ' Establecer el orden de las columnas para DGV_ListProductosMasVendidos
-            DGV_ListProductosMasVendidos.Columns("ranking").DisplayIndex = 0
-            DGV_ListProductosMasVendidos.Columns("ranking").AutoSizeMode = DataGridViewAutoSizeColumnMode.ColumnHeader
-            DGV_ListProductosMasVendidos.Columns("nombre").DisplayIndex = 1
-            DGV_ListProductosMasVendidos.Columns("cantidad").DisplayIndex = 2
-            DGV_ListProductosMasVendidos.Columns("total").DisplayIndex = 3
+            With DGV_ListProductosMasVendidos
+                .Columns("ranking").DisplayIndex = 0
+                .Columns("ranking").AutoSizeMode = DataGridViewAutoSizeColumnMode.ColumnHeader
+                .Columns("nombre").DisplayIndex = 1
+                .Columns("cantidad").DisplayIndex = 2
+                .Columns("total").DisplayIndex = 3
+            End With
+
+        End Sub
+
+        Private Sub BTN_TodayRepProd_Click(sender As Object, e As EventArgs) Handles BTN_TodayRepProd.Click
+            EstablecerFechaActual()
         End Sub
 #End Region
 
@@ -524,8 +570,6 @@ Namespace SistemaFacturacion.Forms.Reportes
         Private Sub P_ReporteVentas_FormClosing(sender As Object, e As FormClosingEventArgs) Handles MyBase.FormClosing
             ManejarCierreONavegacion(e)
         End Sub
-
-
 #End Region
     End Class
 

--- a/SistemaFacturación/Modules/Md_Reportes.vb
+++ b/SistemaFacturación/Modules/Md_Reportes.vb
@@ -94,16 +94,16 @@ Namespace SistemaFacturacion.Modules
             Dim consulta As String = "
                 SELECT
                     f.ID,
-                    f.num_factura AS '# Fact',
+                    f.num_factura AS '#',
                     f.fecha_emision AS 'Fecha de emisión',
                     c.nombre AS 'Cliente',
                     u.usuario As 'Cajero',
-                    fc.comentario  As 'Comentario',
+                    f.tipo_venta AS 'tipo',
                     f.efectivo_cliente AS 'Efectivo',
                     f.tarjeta_cliente AS 'Tarjeta',
+                    f.vuelto  As Vuelto,
                     f.total AS 'Total',
-                    f.tipo_venta AS 'tipo',
-                    f.vuelto  As Vuelto
+                    fc.comentario  As 'Comentario'
                 FROM
                     factura f
                 INNER JOIN
@@ -183,15 +183,15 @@ Namespace SistemaFacturacion.Modules
             For Each row As DataRow In t.Tables(0).Rows
                 Dim factura As New Cls_DatosFactura With {
                     .IdFactura = row.Item("ID").ToString(),
-                    .NumFactura = row.Item("# Fact").ToString(),
+                    .NumFactura = row.Item("#").ToString(),
                     .Fecha = Convert.ToDateTime(row.Item("Fecha de emisión")),
                     .Cliente = row.Item("Cliente").ToString(),
                     .Cajero = row.Item("Cajero").ToString(),
-                    .Comentario = row.Item("Comentario").ToString(),
                     .Efectivo = Convert.ToDecimal(row.Item("Efectivo")),
                     .Tarjeta = Convert.ToDecimal(row.Item("Tarjeta")),
                     .TotalCaja = Convert.ToDecimal(row.Item("Total")),
-                    .Vuelto = Convert.ToDecimal(row.Item("Vuelto"))
+                    .Vuelto = Convert.ToDecimal(row.Item("Vuelto")),
+                    .Comentario = row.Item("Comentario").ToString()
                 }
 
                 'Se obtiene el número del tipo de venta
@@ -302,8 +302,7 @@ Namespace SistemaFacturacion.Modules
                     pos = New PointF(10, 10)
                     'Se obtiene la información relevante de la base de datos
                     Dim reporte As Cls_ReporteVentas = Await GenerarReporte(desde, hasta, T1)
-                    Log.Information("Reporte de ventas generado: {numVentas}, Total: {montoTotal}", reporte.num_ventas, reporte.total_ventas)
-                    Dim cultura As New CultureInfo("es-CR")
+                    Log.Information("Reporte de ventas generado. Ventas: {numVentas}, Total: {montoTotal}", reporte.num_ventas, reporte.total_ventas)
 
                     Dim listaFiltrada = reporte.ListaVentas.Select(Function(venta) New With {
                             venta.NumFactura,
@@ -311,7 +310,7 @@ Namespace SistemaFacturacion.Modules
                             venta.Cajero,
                             venta.Cliente,
                             venta.TipoPago,
-                            .TotalCaja = venta.TotalCaja.ToString("C", New CultureInfo("es-CR"))})
+                            .TotalCaja = venta.TotalCaja.ToString("C", CrCultureInfo)})
 
                     'Se obtienen los datos de la sucursal
                     Dim sucursal As Cls_Sucursal = Await GetInfoSucursal()

--- a/SistemaFacturación/Modules/Md_formating.vb
+++ b/SistemaFacturación/Modules/Md_formating.vb
@@ -1,8 +1,12 @@
-﻿Imports Guna.UI2.WinForms
+﻿Imports System.Globalization
+Imports Guna.UI2.WinForms
 Imports Serilog
 Namespace SistemaFacturacion.Modules
 
     Module Md_formating
+
+        Public CrCultureInfo As New CultureInfo("es-CR")
+
         Friend Sub FormatHeaderText(formatedNames As Dictionary(Of String, String), DGV As Guna2DataGridView)
             For Each formatedName In formatedNames
                 If DGV.Columns.Contains(formatedName.Key) Then

--- a/SistemaFacturación/My Project/AssemblyInfo.vb
+++ b/SistemaFacturación/My Project/AssemblyInfo.vb
@@ -28,5 +28,5 @@ Imports System.Runtime.InteropServices
 '      Revisión
 '
 
-<Assembly: AssemblyVersion("3.0.9")>
-<Assembly: AssemblyFileVersion("3.0.9")>
+<Assembly: AssemblyVersion("3.0.10")>
+<Assembly: AssemblyFileVersion("3.0.10")>

--- a/SistemaFacturación/SistemaFacturación.vbproj
+++ b/SistemaFacturación/SistemaFacturación.vbproj
@@ -35,7 +35,7 @@
     <WebPage>publish.htm</WebPage>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>3.0.9.0</ApplicationVersion>
+    <ApplicationVersion>3.0.10.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <CreateDesktopShortcut>true</CreateDesktopShortcut>
     <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
## Nuevo
- Se agregó un botón en las secciones de reportes que permite colocar de forma automátca los datos del día actual en los campos del rango de fechas.
- Closes #94: Ahora, por defecto, en los reportes de productos el valor por defecto del campo "Cantidad" pasó de 1 a 10, esto para mostrar por defecto los 10 productos más vendidos ya que el valor anterior no tenía sentido práctico

## Bugfix
- Closes #93: Se arregló un error en el que al intentar descargar el pdf de un reporte que tuviera cualquier fecha que no fuera la del día actual provocaba que este se creara en blanco
- Closes: 92: Se arregló un error en el que el límite superior del rango de las fechas en los reportes no estaban funcionan correctamente en algunos casos
- Se mejoró el estilado de la tabla donde se muestran los reportes de ventas, la cual ahora se adapta de mejor manera dependiendo del tamaño de la pantalla